### PR TITLE
Add cross-run result similarity comparison script and UI display

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -148,6 +148,14 @@ def save_comparison(paper_id: str, comparison: PaperComparison):
     return data
 
 
+@router.get("/papers/{paper_id}/results-comparison")
+def get_results_comparison(paper_id: str):
+    data = paper_svc.load_results_comparison(paper_id)
+    if data is None:
+        raise HTTPException(404, "No results comparison found")
+    return data
+
+
 @router.post("/papers/refresh")
 def refresh_papers():
     global _papers_cache

--- a/app/papers.py
+++ b/app/papers.py
@@ -250,6 +250,17 @@ def save_comparison(paper_id: str, reviewer: str, data: dict) -> None:
     p.write_text(json.dumps(data, indent=2))
 
 
+def load_results_comparison(paper_id: str) -> dict | None:
+    """Load compare_results_report.json from the paper directory, if it exists."""
+    p = PAPERS_DIR / paper_id / "compare_results_report.json"
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return None
+
+
 def list_reviews(paper_id: str, run_id: str) -> list[dict]:
     """List all review files for a paper/run."""
     d = _review_dir(paper_id, run_id)

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -63,6 +63,7 @@
     const modalError = $("#modal-error");
 
     // Comparison elements
+    const resultsComparisonSection = $("#results-comparison-section");
     const comparisonComment = $("#comparison-comment");
     const comparisonSaveStatus = $("#comparison-save-status");
 
@@ -110,6 +111,7 @@
         reviewView.classList.add("hidden");
         runsListView.classList.remove("hidden");
         initComparison(paperData);
+        loadResultsComparison(paperData.paper_id);
     }
 
 
@@ -213,6 +215,212 @@
             `;
             tr.addEventListener("click", () => showRunsList(paper));
             papersTbody.appendChild(tr);
+        });
+    }
+
+    // --- Results Comparison ---
+
+    async function loadResultsComparison(paperId) {
+        resultsComparisonSection.classList.add("hidden");
+        resultsComparisonSection.innerHTML = "";
+        const res = await fetch(`/api/papers/${paperId}/results-comparison`);
+        if (!res.ok) return;
+        const data = await res.json();
+        renderResultsComparison(data);
+        resultsComparisonSection.classList.remove("hidden");
+    }
+
+    function renderResultsComparison(data) {
+        const { overall_summary, pairwise } = data;
+
+        // ── Overall summary table ────────────────────────────────────────────
+        const summaryRows = overall_summary.map((row) => `
+            <tr>
+                <td class="rc-pair-label">${esc(row.pair)}</td>
+                <td class="rc-metric">${esc(row.avg_result_similarity)}</td>
+                <td class="rc-metric">${esc(row.result_match_rate)}</td>
+                <td class="rc-metric">${esc(row.evaluation_type_agreement)}</td>
+                <td class="rc-metric">${esc(row.result_type_agreement)}</td>
+                <td class="rc-metric">${esc(row.avg_claim_set_jaccard)}</td>
+                <td class="rc-metric">${esc(row.avg_claim_similarity)}</td>
+            </tr>
+        `).join("");
+
+        // ── Per-pair accordion ───────────────────────────────────────────────
+        const pairSections = pairwise.map((pair, pairIdx) => {
+            const s = pair.summary;
+            const m = s.metrics;
+
+            // Distribution rows
+            const evalTypes = Object.keys(s.evaluation_type_distribution);
+            const evalDistRows = evalTypes.map((t) => {
+                const counts = s.evaluation_type_distribution[t];
+                const [aLabel, bLabel] = [pair.label_a, pair.label_b];
+                return `<tr>
+                    <td class="rc-dist-label">${esc(t)}</td>
+                    <td class="rc-dist-val">${counts[aLabel] ?? 0}</td>
+                    <td class="rc-dist-val">${counts[bLabel] ?? 0}</td>
+                </tr>`;
+            }).join("");
+
+            const resTypes = Object.keys(s.result_type_distribution);
+            const resDistRows = resTypes.map((t) => {
+                const counts = s.result_type_distribution[t];
+                const [aLabel, bLabel] = [pair.label_a, pair.label_b];
+                return `<tr>
+                    <td class="rc-dist-label">${esc(t)}</td>
+                    <td class="rc-dist-val">${counts[aLabel] ?? 0}</td>
+                    <td class="rc-dist-val">${counts[bLabel] ?? 0}</td>
+                </tr>`;
+            }).join("");
+
+            // Matched pairs
+            const matchedRows = s.matched_pairs.map((mp, mpIdx) => {
+                const evalIcon = mp.evaluation_type_match ? "✓" : "✗";
+                const typeIcon = mp.result_type_match ? "✓" : "✗";
+                const evalCls = mp.evaluation_type_match ? "rc-check-pass" : "rc-check-fail";
+                const typeCls = mp.result_type_match ? "rc-check-pass" : "rc-check-fail";
+                const claimPairsId = `rc-claims-${pairIdx}-${mpIdx}`;
+
+                const claimPairRows = mp.matched_claim_pairs.map((cp) => `
+                    <div class="rc-claim-pair">
+                        <div class="rc-claim-sim">${esc(cp.similarity)}</div>
+                        <div class="rc-claim-texts">
+                            <div class="rc-claim-text">${esc(cp.claim_a)}</div>
+                            <div class="rc-claim-text rc-claim-b">${esc(cp.claim_b)}</div>
+                        </div>
+                    </div>
+                `).join("");
+
+                const claimsToggle = mp.matched_claim_pairs.length > 0 ? `
+                    <button class="rc-claims-toggle" data-target="${claimPairsId}">
+                        ${mp.n_matched_claims} matched claim${mp.n_matched_claims !== 1 ? "s" : ""}
+                    </button>
+                    <div id="${claimPairsId}" class="rc-claim-pairs hidden">${claimPairRows}</div>
+                ` : `<span class="rc-no-claims">0 matched claims</span>`;
+
+                return `
+                    <div class="rc-matched-pair">
+                        <div class="rc-matched-pair-header">
+                            <span class="rc-pair-ids">${esc(mp.ids)}</span>
+                            <span class="rc-sim-badge">${esc(mp.result_similarity)}</span>
+                            <span class="${evalCls}" title="Evaluation type match">${evalIcon} Eval</span>
+                            <span class="${typeCls}" title="Result type match">${typeIcon} Type</span>
+                            <span class="rc-claim-counts">${esc(mp.claims)}</span>
+                            <span class="rc-jaccard">Jaccard ${esc(mp.claim_set_jaccard)}</span>
+                        </div>
+                        <div class="rc-result-texts">
+                            <div class="rc-result-text rc-result-a">
+                                <span class="rc-run-tag">${esc(pair.label_a)}</span>
+                                ${esc(mp.result_a)}
+                            </div>
+                            <div class="rc-result-text rc-result-b">
+                                <span class="rc-run-tag">${esc(pair.label_b)}</span>
+                                ${esc(mp.result_b)}
+                            </div>
+                        </div>
+                        ${claimsToggle}
+                    </div>
+                `;
+            }).join("");
+
+            // Unmatched
+            const unmatchedA = s.unmatched_a.length > 0 ? `
+                <div class="rc-unmatched">
+                    <span class="rc-unmatched-label">Only in ${esc(pair.label_a)} (${s.unmatched_a.length})</span>
+                    ${s.unmatched_a.map((r) => `<div class="rc-unmatched-item">${esc(r)}</div>`).join("")}
+                </div>` : "";
+            const unmatchedB = s.unmatched_b.length > 0 ? `
+                <div class="rc-unmatched">
+                    <span class="rc-unmatched-label">Only in ${esc(pair.label_b)} (${s.unmatched_b.length})</span>
+                    ${s.unmatched_b.map((r) => `<div class="rc-unmatched-item">${esc(r)}</div>`).join("")}
+                </div>` : "";
+
+            const bodyId = `rc-pair-body-${pairIdx}`;
+            return `
+                <div class="rc-pair-section">
+                    <button class="rc-pair-toggle" data-body="${bodyId}">
+                        <span class="rc-pair-toggle-label">${esc(s.pair)}</span>
+                        <span class="rc-stat-pill">${esc(m.result_level.avg_result_similarity)} sim</span>
+                        <span class="rc-stat-pill">${esc(m.result_level.result_match_rate)} matched</span>
+                        <span class="rc-stat-pill">${esc(m.result_level.evaluation_type_agreement)} eval agr</span>
+                        <span class="rc-toggle-arrow">▾</span>
+                    </button>
+                    <div id="${bodyId}" class="rc-pair-body hidden">
+                        <div class="rc-distributions">
+                            <table class="rc-dist-table">
+                                <thead><tr>
+                                    <th>Eval Type</th>
+                                    <th>${esc(pair.label_a)}</th>
+                                    <th>${esc(pair.label_b)}</th>
+                                </tr></thead>
+                                <tbody>${evalDistRows}</tbody>
+                            </table>
+                            <table class="rc-dist-table">
+                                <thead><tr>
+                                    <th>Result Type</th>
+                                    <th>${esc(pair.label_a)}</th>
+                                    <th>${esc(pair.label_b)}</th>
+                                </tr></thead>
+                                <tbody>${resDistRows}</tbody>
+                            </table>
+                        </div>
+                        <div class="rc-matched-pairs">
+                            <div class="rc-sub-heading">Matched Results (${m.matched_pairs})</div>
+                            ${matchedRows || '<p class="rc-empty">No matched result pairs above threshold.</p>'}
+                        </div>
+                        ${unmatchedA}${unmatchedB}
+                    </div>
+                </div>
+            `;
+        }).join("");
+
+        resultsComparisonSection.innerHTML = `
+            <div class="comparison-section rc-section">
+                <div class="comparison-header">
+                    <h2>Run Similarity Analysis</h2>
+                    <span class="field-hint">— automated comparison of results and claims across runs</span>
+                </div>
+                <div class="rc-body">
+                    <table class="rc-summary-table">
+                        <thead>
+                            <tr>
+                                <th>Pair</th>
+                                <th class="rc-tip" data-tooltip="Average cosine similarity between matched result descriptions across the two runs. Higher means the runs produced more semantically similar result summaries.">Result Sim</th>
+                                <th class="rc-tip" data-tooltip="Fraction of results (from the larger run) that were matched to a result in the other run above the similarity threshold. Lower means more results were unique to one run.">Match Rate</th>
+                                <th class="rc-tip" data-tooltip="Among matched result pairs, the fraction where both runs assigned the same evaluation (SUPPORTED vs UNSUPPORTED). High agreement means the LLM reached consistent conclusions.">Eval Agr</th>
+                                <th class="rc-tip" data-tooltip="Among matched result pairs, the fraction where both runs assigned the same significance (MAJOR vs MINOR). Disagreement here suggests the runs differ in how important they rated findings.">Type Agr</th>
+                                <th class="rc-tip" data-tooltip="Average Jaccard index of claim sets within matched result pairs: matched claims ÷ union of claims. Measures how much the supporting evidence overlaps between runs.">Claim Jac</th>
+                                <th class="rc-tip" data-tooltip="Average cosine similarity of matched claim pairs within each matched result. Captures how similarly the two runs worded the same underlying claim.">Claim Sim</th>
+                            </tr>
+                        </thead>
+                        <tbody>${summaryRows}</tbody>
+                    </table>
+                    <div class="rc-accordion">${pairSections}</div>
+                </div>
+            </div>
+        `;
+
+        // Wire up pair toggles
+        resultsComparisonSection.querySelectorAll(".rc-pair-toggle").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                const body = document.getElementById(btn.dataset.body);
+                const arrow = btn.querySelector(".rc-toggle-arrow");
+                body.classList.toggle("hidden");
+                arrow.textContent = body.classList.contains("hidden") ? "▾" : "▴";
+            });
+        });
+
+        // Wire up claims-within-result toggles
+        resultsComparisonSection.querySelectorAll(".rc-claims-toggle").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                const target = document.getElementById(btn.dataset.target);
+                target.classList.toggle("hidden");
+                const count = btn.textContent.trim().split(" ")[0];
+                btn.textContent = target.classList.contains("hidden")
+                    ? `${count} matched claim${count !== "1" ? "s" : ""}`
+                    : `Hide claim pairs`;
+            });
         });
     }
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -971,3 +971,424 @@ mark.highlight {
     color: #dc3545;
     margin-top: 8px;
 }
+
+/* ── Run Similarity Analysis section ──────────────────────────────────────── */
+
+.rc-section {
+    margin-top: 28px;
+}
+
+.rc-body {
+    padding: 16px 22px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+/* Summary table */
+.rc-summary-table {
+    font-size: 0.82rem;
+    border-radius: 6px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.rc-summary-table th {
+    font-size: 0.72rem;
+    cursor: default;
+}
+
+.rc-summary-table th.rc-tip {
+    cursor: help;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    position: relative;
+}
+
+.rc-summary-table th.rc-tip:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 240px;
+    background: #1a1a1a;
+    color: #f0f0f0;
+    font-size: 0.75rem;
+    font-weight: 400;
+    line-height: 1.5;
+    text-transform: none;
+    letter-spacing: 0;
+    padding: 8px 11px;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+    white-space: normal;
+    z-index: 200;
+    pointer-events: none;
+}
+
+.rc-summary-table th.rc-tip:hover::before {
+    content: "";
+    position: absolute;
+    top: calc(100% + 1px);
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-bottom-color: #1a1a1a;
+    z-index: 201;
+    pointer-events: none;
+}
+
+/* Right-align tooltip for the last two columns to prevent viewport overflow */
+.rc-summary-table th.rc-tip:nth-last-child(-n+2):hover::after {
+    left: auto;
+    right: 0;
+    transform: none;
+}
+
+.rc-summary-table th.rc-tip:nth-last-child(-n+2):hover::before {
+    left: auto;
+    right: 16px;
+    transform: none;
+}
+
+.rc-summary-table tbody tr {
+    cursor: default;
+}
+
+.rc-summary-table tbody tr:hover {
+    background: #f8f8f8;
+}
+
+.rc-pair-label {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.8rem;
+    color: #444;
+    white-space: nowrap;
+}
+
+.rc-metric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: #333;
+    white-space: nowrap;
+}
+
+/* Accordion */
+.rc-accordion {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.rc-pair-section {
+    border: 1px solid #e3e6ea;
+    border-radius: 7px;
+    overflow: hidden;
+}
+
+.rc-pair-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: #fafafa;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    font-size: 0.82rem;
+    color: #1a1a1a;
+    transition: background 0.12s;
+}
+
+.rc-pair-toggle:hover {
+    background: #f0f4ff;
+}
+
+.rc-pair-toggle-label {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: #333;
+    flex-shrink: 0;
+}
+
+.rc-stat-pill {
+    background: #eef2ff;
+    color: #3455a4;
+    border-radius: 10px;
+    padding: 2px 8px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.rc-toggle-arrow {
+    margin-left: auto;
+    color: #999;
+    font-size: 0.8rem;
+    flex-shrink: 0;
+}
+
+/* Pair body */
+.rc-pair-body {
+    padding: 14px 16px 16px;
+    border-top: 1px solid #eee;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+/* Distribution tables */
+.rc-distributions {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.rc-dist-table {
+    flex: 1;
+    min-width: 160px;
+    font-size: 0.8rem;
+    border-radius: 5px;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.rc-dist-table th {
+    font-size: 0.68rem;
+    padding: 6px 10px;
+}
+
+.rc-dist-table td {
+    padding: 5px 10px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.rc-dist-label {
+    color: #444;
+}
+
+.rc-dist-val {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: #333;
+}
+
+/* Matched pairs */
+.rc-sub-heading {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #888;
+    margin-bottom: 6px;
+}
+
+.rc-matched-pairs {
+    display: flex;
+    flex-direction: column;
+}
+
+.rc-matched-pair {
+    border: 1px solid #e8e8e8;
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-bottom: 8px;
+    background: #fafafa;
+}
+
+.rc-matched-pair:last-child {
+    margin-bottom: 0;
+}
+
+.rc-matched-pair-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.rc-pair-ids {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.75rem;
+    color: #555;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.rc-sim-badge {
+    background: #e8f0fe;
+    color: #1a56b0;
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.rc-check-pass {
+    font-size: 0.72rem;
+    color: #155724;
+    background: #d4edda;
+    border-radius: 4px;
+    padding: 1px 6px;
+    flex-shrink: 0;
+}
+
+.rc-check-fail {
+    font-size: 0.72rem;
+    color: #721c24;
+    background: #f8d7da;
+    border-radius: 4px;
+    padding: 1px 6px;
+    flex-shrink: 0;
+}
+
+.rc-claim-counts {
+    font-size: 0.72rem;
+    color: #666;
+    flex-shrink: 0;
+}
+
+.rc-jaccard {
+    font-size: 0.72rem;
+    color: #666;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+/* Result text side-by-side */
+.rc-result-texts {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 8px;
+}
+
+.rc-result-text {
+    font-size: 0.82rem;
+    color: #333;
+    line-height: 1.5;
+    padding: 6px 10px;
+    border-radius: 4px;
+    border-left: 3px solid #ddd;
+    background: #fff;
+}
+
+.rc-result-a { border-left-color: #7cb4f5; }
+.rc-result-b { border-left-color: #f5a67c; }
+
+.rc-run-tag {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-right: 5px;
+    background: #f0f0f0;
+    border-radius: 3px;
+    padding: 1px 5px;
+}
+
+/* Claim pairs within a result */
+.rc-claims-toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.78rem;
+    color: #0066cc;
+    cursor: pointer;
+}
+
+.rc-claims-toggle:hover { text-decoration: underline; }
+
+.rc-no-claims {
+    font-size: 0.78rem;
+    color: #aaa;
+}
+
+.rc-claim-pairs {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.rc-claim-pair {
+    display: flex;
+    gap: 8px;
+    padding: 6px 8px;
+    background: #f8f8f8;
+    border-radius: 4px;
+    border: 1px solid #eee;
+}
+
+.rc-claim-sim {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #1a56b0;
+    flex-shrink: 0;
+    padding-top: 2px;
+    min-width: 30px;
+    text-align: right;
+}
+
+.rc-claim-texts {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+}
+
+.rc-claim-text {
+    font-size: 0.78rem;
+    color: #444;
+    line-height: 1.45;
+}
+
+.rc-claim-b {
+    color: #666;
+    padding-top: 3px;
+    border-top: 1px solid #e8e8e8;
+}
+
+/* Unmatched results */
+.rc-unmatched {
+    border-left: 3px solid #f0c080;
+    padding: 8px 12px;
+    background: #fffbf0;
+    border-radius: 4px;
+}
+
+.rc-unmatched-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #856404;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    display: block;
+    margin-bottom: 6px;
+}
+
+.rc-unmatched-item {
+    font-size: 0.81rem;
+    color: #555;
+    line-height: 1.5;
+    padding: 4px 0;
+    border-bottom: 1px solid #ffe8a0;
+}
+
+.rc-unmatched-item:last-child {
+    border-bottom: none;
+}
+
+.rc-empty {
+    font-size: 0.82rem;
+    color: #aaa;
+}

--- a/compare_results.py
+++ b/compare_results.py
@@ -1,0 +1,513 @@
+"""
+compare_results.py — Compare CLLM eval_llm outputs across runs.
+
+Operates at two levels:
+  1. Result-level  — how similar are the grouped result descriptions?
+  2. Claim-set-level — within each matched result pair, how similar are
+                       the underlying claims attached to each result?
+
+Usage:
+    python compare_results.py \
+        --runs papers/2018.01.003/20260407_pymupdf4llm_anthropic \
+               papers/2018.01.003/20260407_segmented_anthropic \
+               papers/2018.01.003/20260407_unsegmented_anthropic \
+        --labels "pymupdf4llm" "segmented" "unsegmented"
+
+    python compare_results.py --runs dir_a dir_b   # labels auto-generated
+
+Each --runs entry is a run directory that contains eval_llm*.json and
+claims*.json (naming varies; the script auto-discovers them via glob).
+
+Outputs:
+    compare_results_report.json — structured data + human-readable summary
+                                  for each pairwise comparison
+
+Dependencies:
+    pip install scikit-learn
+    Optional (better similarity): pip install sentence-transformers
+"""
+
+import json
+import argparse
+import itertools
+from pathlib import Path
+from collections import Counter
+from dataclasses import dataclass, field
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+# ── Optional: sentence-transformers for better semantic similarity ─────────────
+try:
+    from sentence_transformers import SentenceTransformer
+    _ST_MODEL = SentenceTransformer("all-MiniLM-L6-v2")
+    USE_SEMANTIC = True
+except ImportError:
+    USE_SEMANTIC = False
+
+
+# ── Data models ───────────────────────────────────────────────────────────────
+
+@dataclass
+class Result:
+    result_id: str
+    result: str                 # grouped result description text
+    claim_ids: list[str]
+    claim_texts: list[str]      # resolved from claims.json
+    evaluation_type: str        # SUPPORTED | UNSUPPORTED
+    result_type: str            # MAJOR | MINOR
+    evaluation: str             # reviewer commentary
+
+
+@dataclass
+class MatchedClaimPair:
+    claim_a: str
+    claim_b: str
+    similarity: float
+
+
+@dataclass
+class MatchedResultPair:
+    id_a: str
+    id_b: str
+    result_a: str
+    result_b: str
+    result_similarity: float
+    evaluation_type_match: bool
+    result_type_match: bool
+    # claim-set comparison within this matched result pair
+    n_claims_a: int
+    n_claims_b: int
+    n_matched_claims: int
+    claim_set_jaccard: float        # matched / union of claim counts
+    avg_claim_similarity: float     # mean similarity of matched claim pairs
+    matched_claim_pairs: list[MatchedClaimPair] = field(default_factory=list)
+
+
+@dataclass
+class PairwiseReport:
+    label_a: str
+    label_b: str
+    n_results_a: int
+    n_results_b: int
+    matched_pairs: list[MatchedResultPair] = field(default_factory=list)
+    unmatched_a: list[str] = field(default_factory=list)  # result texts
+    unmatched_b: list[str] = field(default_factory=list)
+    # result-level aggregate metrics
+    avg_result_similarity: float = 0.0
+    result_match_rate: float = 0.0
+    evaluation_type_agreement: float = 0.0
+    result_type_agreement: float = 0.0
+    # claim-set aggregate metrics
+    avg_claim_set_jaccard: float = 0.0
+    avg_claim_similarity: float = 0.0
+    # distributions
+    distribution_a: dict = field(default_factory=dict)
+    distribution_b: dict = field(default_factory=dict)
+
+
+# ── File discovery ─────────────────────────────────────────────────────────────
+
+def find_json(run_dir: Path, prefix: str) -> Path:
+    """Find the first JSON file in run_dir whose name starts with prefix."""
+    matches = sorted(run_dir.glob(f"{prefix}*.json"))
+    if not matches:
+        raise FileNotFoundError(
+            f"No file matching '{prefix}*.json' found in {run_dir}"
+        )
+    return matches[0]
+
+
+# ── Loaders ───────────────────────────────────────────────────────────────────
+
+def load_claims_map(run_dir: Path) -> dict[str, str]:
+    """Return {claim_id: claim_text} from claims*.json in run_dir."""
+    path = find_json(run_dir, "claims")
+    with open(path) as f:
+        raw = json.load(f)
+    return {item["claim_id"]: item.get("claim", "") for item in raw}
+
+
+def load_results(run_dir: Path) -> list[Result]:
+    """Load eval_llm*.json from run_dir, resolving claim IDs to claim texts."""
+    path = find_json(run_dir, "eval_llm")
+    with open(path) as f:
+        raw = json.load(f)
+
+    claims_map = load_claims_map(run_dir)
+
+    results = []
+    for item in raw:
+        claim_ids = item.get("claim_ids", [])
+        results.append(Result(
+            result_id=item.get("result_id", ""),
+            result=item.get("result", ""),
+            claim_ids=claim_ids,
+            claim_texts=[claims_map.get(cid, "") for cid in claim_ids],
+            evaluation_type=item.get("evaluation_type", ""),
+            result_type=item.get("result_type", ""),
+            evaluation=item.get("evaluation", ""),
+        ))
+    return results
+
+
+# ── Embedding ─────────────────────────────────────────────────────────────────
+
+def embed(texts: list[str]) -> np.ndarray:
+    """Return embedding matrix (n_texts × dim)."""
+    if not texts:
+        return np.empty((0, 1))
+    if USE_SEMANTIC:
+        return _ST_MODEL.encode(texts, show_progress_bar=False)
+    vec = TfidfVectorizer(ngram_range=(1, 2), min_df=1)
+    return vec.fit_transform(texts).toarray()
+
+
+# ── Greedy matching ───────────────────────────────────────────────────────────
+
+def greedy_match_texts(
+    texts_a: list[str],
+    texts_b: list[str],
+    threshold: float,
+) -> tuple[list[tuple[int, int, float]], set[int], set[int]]:
+    """
+    Greedy bipartite matching by cosine similarity.
+    Returns (matched_index_pairs_with_sim, matched_a_indices, matched_b_indices).
+    """
+    if not texts_a or not texts_b:
+        return [], set(), set()
+
+    all_texts = texts_a + texts_b
+    embeddings = embed(all_texts)
+    emb_a = embeddings[:len(texts_a)]
+    emb_b = embeddings[len(texts_a):]
+
+    sim_matrix = cosine_similarity(emb_a, emb_b)
+
+    flat = [
+        (sim_matrix[i, j], i, j)
+        for i in range(len(texts_a))
+        for j in range(len(texts_b))
+    ]
+    flat.sort(reverse=True)
+
+    matched_a: set[int] = set()
+    matched_b: set[int] = set()
+    pairs: list[tuple[int, int, float]] = []
+
+    for sim, i, j in flat:
+        if sim < threshold:
+            break
+        if i in matched_a or j in matched_b:
+            continue
+        matched_a.add(i)
+        matched_b.add(j)
+        pairs.append((i, j, float(sim)))
+
+    return pairs, matched_a, matched_b
+
+
+# ── Claim-set comparison for a matched result pair ────────────────────────────
+
+def compare_claim_sets(
+    claims_a: list[str],
+    claims_b: list[str],
+    threshold: float,
+) -> tuple[float, float, list[MatchedClaimPair]]:
+    """
+    Compare the claims attached to two matched results.
+
+    Returns:
+        claim_set_jaccard  — matched_count / union_count
+        avg_claim_sim      — mean similarity of matched claim pairs
+        matched_pairs      — list of MatchedClaimPair
+    """
+    if not claims_a and not claims_b:
+        return 1.0, 1.0, []
+    if not claims_a or not claims_b:
+        return 0.0, 0.0, []
+
+    pairs, matched_a, matched_b = greedy_match_texts(claims_a, claims_b, threshold)
+
+    n_matched = len(pairs)
+    union = len(claims_a) + len(claims_b) - n_matched
+    jaccard = n_matched / union if union > 0 else 0.0
+    avg_sim = float(np.mean([s for _, _, s in pairs])) if pairs else 0.0
+
+    matched_pairs = [
+        MatchedClaimPair(
+            claim_a=claims_a[i],
+            claim_b=claims_b[j],
+            similarity=round(s, 4),
+        )
+        for i, j, s in pairs
+    ]
+
+    return round(jaccard, 4), round(avg_sim, 4), matched_pairs
+
+
+# ── Distributions ─────────────────────────────────────────────────────────────
+
+def distributions(results: list[Result]) -> dict:
+    return {
+        "evaluation_type": dict(Counter(r.evaluation_type for r in results)),
+        "result_type": dict(Counter(r.result_type for r in results)),
+    }
+
+
+# ── Pairwise comparison ───────────────────────────────────────────────────────
+
+def compare_pair(
+    label_a: str, results_a: list[Result],
+    label_b: str, results_b: list[Result],
+    result_threshold: float = 0.5,
+    claim_threshold: float = 0.4,
+) -> PairwiseReport:
+    texts_a = [r.result for r in results_a]
+    texts_b = [r.result for r in results_b]
+
+    idx_pairs, matched_a_idx, matched_b_idx = greedy_match_texts(
+        texts_a, texts_b, result_threshold
+    )
+
+    matched_pairs: list[MatchedResultPair] = []
+    for i, j, sim in idx_pairs:
+        ra, rb = results_a[i], results_b[j]
+
+        jaccard, avg_csim, claim_pairs = compare_claim_sets(
+            ra.claim_texts, rb.claim_texts, claim_threshold
+        )
+
+        matched_pairs.append(MatchedResultPair(
+            id_a=ra.result_id,
+            id_b=rb.result_id,
+            result_a=ra.result,
+            result_b=rb.result,
+            result_similarity=round(sim, 4),
+            evaluation_type_match=(ra.evaluation_type == rb.evaluation_type),
+            result_type_match=(ra.result_type == rb.result_type),
+            n_claims_a=len(ra.claim_texts),
+            n_claims_b=len(rb.claim_texts),
+            n_matched_claims=len(claim_pairs),
+            claim_set_jaccard=jaccard,
+            avg_claim_similarity=avg_csim,
+            matched_claim_pairs=claim_pairs,
+        ))
+
+    unmatched_a = [results_a[i].result for i in range(len(results_a)) if i not in matched_a_idx]
+    unmatched_b = [results_b[j].result for j in range(len(results_b)) if j not in matched_b_idx]
+
+    report = PairwiseReport(
+        label_a=label_a,
+        label_b=label_b,
+        n_results_a=len(results_a),
+        n_results_b=len(results_b),
+        matched_pairs=matched_pairs,
+        unmatched_a=unmatched_a,
+        unmatched_b=unmatched_b,
+        distribution_a=distributions(results_a),
+        distribution_b=distributions(results_b),
+    )
+
+    if matched_pairs:
+        report.avg_result_similarity = round(
+            float(np.mean([p.result_similarity for p in matched_pairs])), 4
+        )
+        report.result_match_rate = round(
+            len(matched_pairs) / max(len(results_a), len(results_b)), 4
+        )
+        report.evaluation_type_agreement = round(
+            sum(p.evaluation_type_match for p in matched_pairs) / len(matched_pairs), 4
+        )
+        report.result_type_agreement = round(
+            sum(p.result_type_match for p in matched_pairs) / len(matched_pairs), 4
+        )
+        report.avg_claim_set_jaccard = round(
+            float(np.mean([p.claim_set_jaccard for p in matched_pairs])), 4
+        )
+        report.avg_claim_similarity = round(
+            float(np.mean([p.avg_claim_similarity for p in matched_pairs])), 4
+        )
+
+    return report
+
+
+# ── Human-readable summary (stored in JSON for UI rendering) ──────────────────
+
+def build_summary(report: PairwiseReport) -> dict:
+    """
+    Build a human-readable summary dict for a pairwise report.
+    All metric values are pre-formatted as percentage strings so the UI
+    can render them directly without further computation.
+    """
+    metrics = {
+        "results": f"{report.n_results_a} vs {report.n_results_b}",
+        "matched_pairs": len(report.matched_pairs),
+        "unmatched_a": len(report.unmatched_a),
+        "unmatched_b": len(report.unmatched_b),
+        "result_level": {
+            "avg_result_similarity": f"{report.avg_result_similarity:.1%}",
+            "result_match_rate": f"{report.result_match_rate:.1%}",
+            "evaluation_type_agreement": f"{report.evaluation_type_agreement:.1%}",
+            "result_type_agreement": f"{report.result_type_agreement:.1%}",
+        },
+        "claim_set_level": {
+            "avg_claim_set_jaccard": f"{report.avg_claim_set_jaccard:.1%}",
+            "avg_claim_similarity": f"{report.avg_claim_similarity:.1%}",
+        },
+    }
+
+    all_eval = (
+        set(report.distribution_a["evaluation_type"])
+        | set(report.distribution_b["evaluation_type"])
+    )
+    eval_dist = {
+        t: {report.label_a: report.distribution_a["evaluation_type"].get(t, 0),
+            report.label_b: report.distribution_b["evaluation_type"].get(t, 0)}
+        for t in sorted(all_eval)
+    }
+
+    all_res = (
+        set(report.distribution_a["result_type"])
+        | set(report.distribution_b["result_type"])
+    )
+    result_type_dist = {
+        t: {report.label_a: report.distribution_a["result_type"].get(t, 0),
+            report.label_b: report.distribution_b["result_type"].get(t, 0)}
+        for t in sorted(all_res)
+    }
+
+    matched_pairs_summary = [
+        {
+            "ids": f"{p.id_a} ↔ {p.id_b}",
+            "result_similarity": f"{p.result_similarity:.2f}",
+            "evaluation_type_match": p.evaluation_type_match,
+            "result_type_match": p.result_type_match,
+            "claims": f"{p.n_claims_a} (A) / {p.n_claims_b} (B)",
+            "n_matched_claims": p.n_matched_claims,
+            "claim_set_jaccard": f"{p.claim_set_jaccard:.2f}",
+            "avg_claim_similarity": f"{p.avg_claim_similarity:.2f}",
+            "result_a": p.result_a,
+            "result_b": p.result_b,
+            "matched_claim_pairs": [
+                {
+                    "claim_a": cp.claim_a,
+                    "claim_b": cp.claim_b,
+                    "similarity": f"{cp.similarity:.2f}",
+                }
+                for cp in p.matched_claim_pairs
+            ],
+        }
+        for p in sorted(report.matched_pairs, key=lambda p: p.result_similarity, reverse=True)
+    ]
+
+    return {
+        "pair": f"{report.label_a} ↔ {report.label_b}",
+        "metrics": metrics,
+        "evaluation_type_distribution": eval_dist,
+        "result_type_distribution": result_type_dist,
+        "matched_pairs": matched_pairs_summary,
+        "unmatched_a": report.unmatched_a,
+        "unmatched_b": report.unmatched_b,
+    }
+
+
+def build_overall_summary(reports: list[PairwiseReport]) -> list[dict]:
+    """Cross-pair summary table — one row per pair."""
+    return [
+        {
+            "pair": f"{r.label_a} ↔ {r.label_b}",
+            "avg_result_similarity": f"{r.avg_result_similarity:.1%}",
+            "result_match_rate": f"{r.result_match_rate:.1%}",
+            "evaluation_type_agreement": f"{r.evaluation_type_agreement:.1%}",
+            "result_type_agreement": f"{r.result_type_agreement:.1%}",
+            "avg_claim_set_jaccard": f"{r.avg_claim_set_jaccard:.1%}",
+            "avg_claim_similarity": f"{r.avg_claim_similarity:.1%}",
+        }
+        for r in reports
+    ]
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare CLLM eval_llm results across runs at result and claim-set level."
+    )
+    parser.add_argument(
+        "--runs", nargs="+", required=True,
+        help="Run directories (each must contain eval_llm*.json and claims*.json)",
+    )
+    parser.add_argument(
+        "--labels", nargs="+",
+        help="Labels for each run directory (default: directory name)",
+    )
+    parser.add_argument(
+        "--result-threshold", type=float, default=0.5,
+        help="Min cosine similarity to count as a matched result pair (default: 0.5)",
+    )
+    parser.add_argument(
+        "--claim-threshold", type=float, default=0.4,
+        help="Min cosine similarity to match claims within a result pair (default: 0.4)",
+    )
+    parser.add_argument(
+        "--output", default="compare_results_report.json",
+        help="Output JSON report path (default: compare_results_report.json)",
+    )
+    args = parser.parse_args()
+
+    run_dirs = [Path(r) for r in args.runs]
+    labels = args.labels or [d.name for d in run_dirs]
+
+    if len(labels) != len(run_dirs):
+        parser.error("Number of --labels must match number of --runs")
+
+    all_results: dict[str, list[Result]] = {}
+    for label, run_dir in zip(labels, run_dirs):
+        all_results[label] = load_results(run_dir)
+
+    reports: list[PairwiseReport] = []
+    for (la, ra), (lb, rb) in itertools.combinations(all_results.items(), 2):
+        reports.append(compare_pair(
+            la, ra, lb, rb,
+            result_threshold=args.result_threshold,
+            claim_threshold=args.claim_threshold,
+        ))
+
+    out = {
+        "config": {
+            "runs": dict(zip(labels, args.runs)),
+            "result_threshold": args.result_threshold,
+            "claim_threshold": args.claim_threshold,
+            "similarity_backend": "sentence-transformers" if USE_SEMANTIC else "tfidf",
+        },
+        # Cross-pair summary table (one row per pair)
+        "overall_summary": build_overall_summary(reports),
+        # Per-pair: raw metrics + human-readable summary for UI rendering
+        "pairwise": [
+            {
+                "label_a": r.label_a,
+                "label_b": r.label_b,
+                "n_results_a": r.n_results_a,
+                "n_results_b": r.n_results_b,
+                "avg_result_similarity": r.avg_result_similarity,
+                "result_match_rate": r.result_match_rate,
+                "evaluation_type_agreement": r.evaluation_type_agreement,
+                "result_type_agreement": r.result_type_agreement,
+                "avg_claim_set_jaccard": r.avg_claim_set_jaccard,
+                "avg_claim_similarity": r.avg_claim_similarity,
+                "distribution_a": r.distribution_a,
+                "distribution_b": r.distribution_b,
+                "summary": build_summary(r),
+            }
+            for r in reports
+        ],
+    }
+
+    with open(args.output, "w") as f:
+        json.dump(out, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/papers/2018.01.003/compare_results_report.json
+++ b/papers/2018.01.003/compare_results_report.json
@@ -1,0 +1,1492 @@
+{
+  "config": {
+    "runs": {
+      "pymupdf4llm": "papers/2018.01.003/20260407_pymupdf4llm_anthropic",
+      "segmented": "papers/2018.01.003/20260407_segmented_anthropic",
+      "unsegmented": "papers/2018.01.003/20260407_unsegmented_anthropic"
+    },
+    "result_threshold": 0.5,
+    "claim_threshold": 0.4,
+    "similarity_backend": "sentence-transformers"
+  },
+  "overall_summary": [
+    {
+      "pair": "pymupdf4llm \u2194 segmented",
+      "avg_result_similarity": "75.6%",
+      "result_match_rate": "66.7%",
+      "evaluation_type_agreement": "93.8%",
+      "result_type_agreement": "56.2%",
+      "avg_claim_set_jaccard": "46.3%",
+      "avg_claim_similarity": "82.3%"
+    },
+    {
+      "pair": "pymupdf4llm \u2194 unsegmented",
+      "avg_result_similarity": "79.8%",
+      "result_match_rate": "45.8%",
+      "evaluation_type_agreement": "100.0%",
+      "result_type_agreement": "81.8%",
+      "avg_claim_set_jaccard": "59.8%",
+      "avg_claim_similarity": "86.8%"
+    },
+    {
+      "pair": "segmented \u2194 unsegmented",
+      "avg_result_similarity": "79.9%",
+      "result_match_rate": "64.7%",
+      "evaluation_type_agreement": "100.0%",
+      "result_type_agreement": "72.7%",
+      "avg_claim_set_jaccard": "41.9%",
+      "avg_claim_similarity": "88.8%"
+    }
+  ],
+  "pairwise": [
+    {
+      "label_a": "pymupdf4llm",
+      "label_b": "segmented",
+      "n_results_a": 24,
+      "n_results_b": 17,
+      "avg_result_similarity": 0.7562,
+      "result_match_rate": 0.6667,
+      "evaluation_type_agreement": 0.9375,
+      "result_type_agreement": 0.5625,
+      "avg_claim_set_jaccard": 0.4632,
+      "avg_claim_similarity": 0.8228,
+      "distribution_a": {
+        "evaluation_type": {
+          "SUPPORTED": 21,
+          "UNCERTAIN": 3
+        },
+        "result_type": {
+          "MINOR": 12,
+          "MAJOR": 12
+        }
+      },
+      "distribution_b": {
+        "evaluation_type": {
+          "SUPPORTED": 14,
+          "UNCERTAIN": 3
+        },
+        "result_type": {
+          "MAJOR": 9,
+          "MINOR": 8
+        }
+      },
+      "summary": {
+        "pair": "pymupdf4llm \u2194 segmented",
+        "metrics": {
+          "results": "24 vs 17",
+          "matched_pairs": 16,
+          "unmatched_a": 8,
+          "unmatched_b": 1,
+          "result_level": {
+            "avg_result_similarity": "75.6%",
+            "result_match_rate": "66.7%",
+            "evaluation_type_agreement": "93.8%",
+            "result_type_agreement": "56.2%"
+          },
+          "claim_set_level": {
+            "avg_claim_set_jaccard": "46.3%",
+            "avg_claim_similarity": "82.3%"
+          }
+        },
+        "evaluation_type_distribution": {
+          "SUPPORTED": {
+            "pymupdf4llm": 21,
+            "segmented": 14
+          },
+          "UNCERTAIN": {
+            "pymupdf4llm": 3,
+            "segmented": 3
+          }
+        },
+        "result_type_distribution": {
+          "MAJOR": {
+            "pymupdf4llm": 12,
+            "segmented": 9
+          },
+          "MINOR": {
+            "pymupdf4llm": 12,
+            "segmented": 8
+          }
+        },
+        "matched_pairs": [
+          {
+            "ids": "R16 \u2194 R14",
+            "result_similarity": "0.92",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "3 (A) / 2 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.67",
+            "avg_claim_similarity": "1.00",
+            "result_a": "Tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet task demands. The arbitrary 45\u00b0 category boundary must also be learned. These observations suggest PPC functional properties are not hardwired but emerge through learning to solve task requirements.",
+            "result_b": "Tactile orientation tuning may be generated in PPC rather than inherited from barrel cortex, and the arbitrary 45\u00b0 category boundary must be learned, suggesting task-dependent plasticity.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "The reward rule boundary of 45\u00b0 was set arbitrarily, and its neuronal correlate must also be generated to meet behavioral demands.",
+                "claim_b": "The reward rule boundary of 45\u00b0 was set arbitrarily, and its neuronal correlate must also be generated to meet behavioral demands.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "While PPC could receive orientation-tuned signals from earlier stages of visual cortical processing, tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet specific behavioral demands.",
+                "claim_b": "While PPC could receive orientation-tuned signals from earlier stages of visual cortical processing, tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet specific behavioral demands.",
+                "similarity": "1.00"
+              }
+            ]
+          },
+          {
+            "ids": "R4 \u2194 R3",
+            "result_similarity": "0.88",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "4 (A) / 3 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.75",
+            "avg_claim_similarity": "0.97",
+            "result_a": "Rats immediately generalized the categorization rule to novel orientations (90\u00b0-135\u00b0 and -45\u00b0 to 0\u00b0) in the first test session, performing equally well on new versus familiar stimuli (p>0.29 for all rats). This suggests rats solved the task by measuring angular distance from cardinal orientations rather than memorizing specific stimulus-reward associations.",
+            "result_b": "Rats generalized the orientation categorization rule to novel stimuli immediately upon first presentation, suggesting they solved the task by measuring angular distance from cardinal orientations.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats were able to generalize this categorization rule to new stimuli upon the first instance.",
+                "claim_b": "Rats were able to generalize this categorization rule to new stimuli upon the first instance.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats seemed to solve the task by measuring the difference between the encountered orientation and the cardinal orientations of ''horizontal'' and ''vertical.''",
+                "claim_b": "Rats seemed to solve the task by measuring the difference between the encountered orientation and the cardinal orientations of 'horizontal' and 'vertical.'",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "In the first session with novel orientations, each rat performed equally well on the new versus the familiar stimuli (bootstrap test, all rats p > 0.29).",
+                "claim_b": "In the first session with novel orientations, each rat performed equally well on the new versus the familiar stimuli.",
+                "similarity": "0.91"
+              }
+            ]
+          },
+          {
+            "ids": "R1 \u2194 R17",
+            "result_similarity": "0.86",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "6 (A) / 2 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.33",
+            "avg_claim_similarity": "0.96",
+            "result_a": "Rats were trained to categorize grating orientations into two categories (0\u00b0\u00b145\u00b0 as horizontal and 90\u00b0\u00b145\u00b0 as vertical) using a visual-tactile discrimination task with randomly interleaved V, T, and VT trials (32% each) plus 4% control trials. The stimulus was a circular grating (98 mm diameter) with raised parallel bars (3.5 mm width and depth) alternately colored white and black.",
+            "result_b": "The experimental stimulus was a 98mm diameter circular grating with 3.5mm raised bars, and rats were trained to categorize orientations 0-45\u00b0 as horizontal and 45-90\u00b0 as vertical.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats were trained to categorize orientations in the range of 0\u00b0\u201345\u00b0 as horizontal, and orientations in the range of 45\u00b0\u201390\u00b0 as vertical.",
+                "claim_b": "Rats were trained to categorize orientations in the range of 0-45\u00b0 as horizontal, and orientations in the range of 45-90\u00b0 as vertical.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The discriminandum had a circular boundary (98 mm diameter) and raised parallel bars.",
+                "claim_b": "The discriminandum had a circular boundary (98 mm diameter) and raised parallel bars (width and depth of 3.5 mm), alternately colored white and black.",
+                "similarity": "0.92"
+              }
+            ]
+          },
+          {
+            "ids": "R8 \u2194 R6",
+            "result_similarity": "0.85",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "8 (A) / 7 (B)",
+            "n_matched_claims": 7,
+            "claim_set_jaccard": "0.88",
+            "avg_claim_similarity": "0.99",
+            "result_a": "PPC neurons showed task-related activity with two main response profiles: some neurons showed graded orientation tuning (firing rate modulated progressively from 0\u00b0 to 90\u00b0), while others showed categorical tuning (large firing rate changes at the 45\u00b0 boundary with poor modulation within categories). Neuronal responses were similar across V, T, and VT modality conditions.",
+            "result_b": "Individual PPC neurons showed task-related firing patterns that encoded either stimulus orientation in a graded manner or stimulus category with sharp transitions at the boundary, with similar temporal profiles across modalities.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Similar temporal profiles characterized V, T, and VT trials for the example neuron.",
+                "claim_b": "Similar temporal profiles characterized V, T, and VT trials for the example neuron.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The neuron had a stable firing rate of about 2 spikes/s as the rat awaited the trial onset.",
+                "claim_b": "The neuron had a stable firing rate of about 2 spikes/s as the rat awaited the trial onset.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The category-selective neurons were poorly modulated by stimulus orientation within a choice category.",
+                "claim_b": "The category-selective neurons were poorly modulated by stimulus orientation within a choice category.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "About 200 ms after trial onset, the neuron's firing rate ramped upward and remained at about 8 spikes/s until 1 s after trial onset.",
+                "claim_b": "About 200 ms after trial onset, the neuron's firing rate ramped upward and remained at about 8 spikes/s until 1 s after trial onset.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The second example neuron's firing rate was modulated by stimulus orientation, firing at a progressively lower rate from 0\u00b0 to 90\u00b0.",
+                "claim_b": "The second example neuron's firing rates were modulated by stimulus orientation, firing at a progressively lower rate from 0\u00b0 to 90\u00b0.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The first example neuron's firing rate was modulated by stimulus orientation, firing at a progressively higher rate as angle increased from 0\u00b0 to 90\u00b0.",
+                "claim_b": "The first example neuron's firing rates were modulated by stimulus orientation, firing at a progressively higher rate as angle increased from 0\u00b0 to 90\u00b0.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Two neurons carried a large signal about stimulus category, with firing rates deviating according to the upcoming action (left or right).",
+                "claim_b": "Two example neurons carried a large signal about stimulus category, with firing rates deviating according to the upcoming action (left or right).",
+                "similarity": "0.95"
+              }
+            ]
+          },
+          {
+            "ids": "R11 \u2194 R9",
+            "result_similarity": "0.85",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "5 (A) / 6 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.83",
+            "avg_claim_similarity": "0.95",
+            "result_a": "Conditional mutual information analysis revealed that ~50% of neurons (315/622) carried information about category conditional on angle, ~45% (284/622) carried information about angle conditional on category, and ~38% (239/622) carried both. 78% of dual-coding neurons clustered within \u00b10.05 bits of equal information, suggesting PPC is involved in supramodal stimulus-to-category transformation.",
+            "result_b": "PPC neurons jointly encoded stimulus orientation and category through conditional information analysis, with 78% of informative neurons showing both types of coding distributed along a continuum, suggesting PPC participates in stimulus-to-category transformation.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "About 50% of neurons (315 out 622, p < 0.01) carried significant information about category conditional on angle.",
+                "claim_b": "About 50% of neurons (315 out 622, p < 0.01) carried significant information about category conditional on angle.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The simultaneous representation of both task properties suggests that PPC is involved in a supramodal stimulus-to-category transformation.",
+                "claim_b": "The simultaneous representation of both task properties suggests that PPC is involved in a supramodal stimulus-to-category transformation.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "About 45% of neurons (284 out of 622, p < 0.01) carried significant information about stimulus angle conditional upon perceived category.",
+                "claim_b": "About 45% of neurons (284 out of 622, p < 0.01) carried significant information about stimulus angle conditional upon perceived category.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "About 38% of neurons (239 out of 622, p < 0.01, bootstrap test) carried significant conditional information about both orientation and choice.",
+                "claim_b": "About 38% of neurons (239 out of 622, p < 0.01) carried significant conditional information about both orientation and choice.",
+                "similarity": "0.93"
+              },
+              {
+                "claim_a": "78% of neurons that carried information about both angle and category were clustered between the bands (R\u00b10.05 bits of information).",
+                "claim_b": "78% of neurons that carried information about both angle and category were clustered between the bands around the diagonal, indicating that PPC neurons tended to express both stimulus coding and category coding.",
+                "similarity": "0.80"
+              }
+            ]
+          },
+          {
+            "ids": "R13 \u2194 R12",
+            "result_similarity": "0.83",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "3 (A) / 2 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.67",
+            "avg_claim_similarity": "0.78",
+            "result_a": "PPC is involved in supramodal processing of shape, contributing to the formation of a supramodal object representation and participating in percept-to-action transformation. However, this interpretation is based on correlational evidence; causal evidence would require perturbation experiments.",
+            "result_b": "PPC contributes to forming supramodal object representations and participates in percept-to-action transformation, with functional properties emerging through learning rather than being hardwired.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "PPC contributes to the formation of a supramodal representation of the object and participates in the percept-to-action transformation carried out by a network of cortical regions.",
+                "claim_b": "PPC contributes to the formation of a supramodal representation of the object and participates in the percept-to-action transformation carried out by a network of cortical regions.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "This interpretation is based on correlations between trial-by-trial neuronal firing and whole-animal behavior; evidence for a direct causal role of PPC might emerge from external manipulations of this region during execution of the behavior.",
+                "claim_b": "The functional properties of PPC neurons are not hardwired but rather emerge through a learning process in order to solve the requirements of ongoing tasks.",
+                "similarity": "0.55"
+              }
+            ]
+          },
+          {
+            "ids": "R10 \u2194 R8",
+            "result_similarity": "0.82",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "4 (A) / 2 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "0.96",
+            "result_a": "Only 5% (30/622) of PPC neurons showed significant modality selectivity (p<0.01), while over 50% (318/622) showed significant category selectivity (p<0.01). Among category-selective neurons, more preferred rightward choices (219/318), suggesting contralateral preference in left PPC. The population encoded stimulus properties (orientation and category) irrespective of modality.",
+            "result_b": "Over 50% of PPC neurons showed significant selectivity for the rat's upcoming choice, with a bias toward contralateral (right) choices in left PPC.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "A greater number of neurons (219 out of 318 neurons) was selective for turns to the right (index < 0) than to the left (index > 0), suggesting overall opposite-side preference in left PPC.",
+                "claim_b": "A greater number of neurons (219 out of 318 neurons) was selective for turns to the right than to the left, suggesting overall opposite-side preference in left PPC.",
+                "similarity": "0.98"
+              },
+              {
+                "claim_a": "Over 50% of neurons (318 out of 622) were significantly selective (p < 0.01; permutation test) for the upcoming choice of the rat.",
+                "claim_b": "Over 50% of neurons (318 out of 622) were significantly selective (p < 0.01) for the upcoming choice of the rat.",
+                "similarity": "0.93"
+              }
+            ]
+          },
+          {
+            "ids": "R12 \u2194 R10",
+            "result_similarity": "0.79",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "10 (A) / 7 (B)",
+            "n_matched_claims": 7,
+            "claim_set_jaccard": "0.70",
+            "avg_claim_similarity": "0.99",
+            "result_a": "A linear discriminant classifier trained on PPC population activity (300 ms before response) achieved >90% accuracy in predicting rat choices (91-99% in 9/10 sessions, 70% in 1 session, p<0.001). Decoder performance was ~50% before trial onset (indicating no pre-stimulus bias) and increased to >90% by 250 ms before response. Almost all neurons contributed non-zero weights. The classifier replicated behavioral psychometric curves across modalities using cross-modality training, demonstrating supramodal population coding.",
+            "result_b": "A linear classifier trained on PPC population activity could predict rats' choices with >90% accuracy, with performance increasing from chance before stimulus onset to >90% by 250ms before response, and nearly all neurons contributing to classification.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "When tested, the classifier replicated the rat's behavior on over 90% of trials.",
+                "claim_b": "When tested, the classifier replicated the rat's behavior on over 90% of trials.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "This suggests that the PPC population did not manifest a choice bias before encountering the stimulus.",
+                "claim_b": "This suggests that the PPC population did not manifest a choice bias before encountering the stimulus.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Performance gradually increased to >90% on average by around 250 ms before the response lick.",
+                "claim_b": "Performance gradually increased to >90% on average by around 250 ms before the response lick.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Almost all neuronal weights were non-zero in each session, indicating that every neuron in the population contributed to the classifier's performance.",
+                "claim_b": "Almost all neuronal weights were non-zero in each session, indicating that every neuron in the population contributed to the classifier's performance.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The classifier was able to determine a boundary that could separate the population's activity into two states associated with the rat's two choices.",
+                "claim_b": "The classifier was able to determine a boundary that could separate the population's activity into two states associated with the rat's two choices.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Peak decoder performance measured in 5 rats ranged from 91% to 99% (9 sessions), with 1 session at 70% (p < 0.001, permutation test).",
+                "claim_b": "Peak decoder performance measured in 5 rats ranged from 91% to 99% (9 sessions), with 1 session at 70% (p < 0.001).",
+                "similarity": "0.99"
+              },
+              {
+                "claim_a": "About 1 s before the response (i.e., before trial onset), the decoder's performance was around 50%.",
+                "claim_b": "About 1 s before the response, the decoder's performance was around 50%.",
+                "similarity": "0.93"
+              }
+            ]
+          },
+          {
+            "ids": "R19 \u2194 R7",
+            "result_similarity": "0.75",
+            "evaluation_type_match": false,
+            "result_type_match": false,
+            "claims": "4 (A) / 6 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.43",
+            "avg_claim_similarity": "0.51",
+            "result_a": "A previous study (Raposo et al. 2014) found that PPC neurons showed modality selectivity when rats judged quantities of auditory/visual pulses, contrasting with the modality-free coding observed here. The authors hypothesize that supramodal coding arises from simultaneous arrival of congruous signals about a real object, which may better reflect natural statistics.",
+            "result_b": "PPC neuronal responses were largely invariant to stimulus modality, with only 5% of neurons showing modality selectivity, while firing rates remained consistent across visual, tactile, and bimodal conditions.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "In a recent study in which rats judged the quantities of auditory and/or visual pulses in a train, many neurons in PPC responded differentially on trials of the two modalities; indeed, modality itself could be decoded from neuronal firing.",
+                "claim_b": "This population of neurons did not appear to be informative about the modality of the stimulus but instead generated a robust signal about stimulus properties-orientation and the choice category associated with that orientation-irrespective of modality.",
+                "similarity": "0.62"
+              },
+              {
+                "claim_a": "This contrasts with the modality-free coding of the object in our study.",
+                "claim_b": "The independence of firing rate on modality held across the six stimulus orientations.",
+                "similarity": "0.51"
+              },
+              {
+                "claim_a": "We hypothesize that supramodal coding is a consequence of the nearly simultaneous arrival in PPC of congruous signals, through two sensory channels, about a real object.",
+                "claim_b": "Just 5% (30 out of 622) of neurons were selective (p < 0.01) for stimulus modality.",
+                "similarity": "0.41"
+              }
+            ]
+          },
+          {
+            "ids": "R17 \u2194 R13",
+            "result_similarity": "0.75",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "9 (A) / 4 (B)",
+            "n_matched_claims": 4,
+            "claim_set_jaccard": "0.44",
+            "avg_claim_similarity": "1.00",
+            "result_a": "Supralinear multisensory integration has been reported previously and could arise from partial exploitation of unimodal information due to reduced motivation, or from violation of channel independence assumptions. Possible mechanisms include cross-modal sensorimotor interactions (e.g., vision guiding whisker palpation) or cortical synergy (e.g., cross-modal inhibition reducing noise in sensory representations).",
+            "result_b": "Supralinear combination may result from violation of the independence assumption, potentially through behavioral strategies (visual guidance of tactile exploration) or neural mechanisms (cross-modal inhibition of noise).",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Supralinear combination could occur if the information available on unimodal trials were only partially exploited, while the information available on bimodal trials were completely exploited.",
+                "claim_b": "Supralinear combination could occur if the information available on unimodal trials were only partially exploited, while the information available on bimodal trials were completely exploited.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Inhibition between cortical regions could allow activity evoked through one modality to suppress the non-specific noise in the other modality's stimulus representation.",
+                "claim_b": "Inhibition between cortical regions could allow activity evoked through one modality to suppress the non-specific noise in the other modality's stimulus representation.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The visual cue might help the rat palpate the surface with its whiskers more efficiently, boosting the tactile signal.",
+                "claim_b": "The visual cue might help the rat palpate the surface with its whiskers more efficiently, boosting the tactile signal.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The observed supralinearity could result from a violation of the independence assumption\u2014visual and tactile signals might not be processed independently in bimodal trials.",
+                "claim_b": "The observed supralinearity could result from a violation of the independence assumption - visual and tactile signals might not be processed independently in bimodal trials.",
+                "similarity": "1.00"
+              }
+            ]
+          },
+          {
+            "ids": "R14 \u2194 R1",
+            "result_similarity": "0.71",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "3 (A) / 10 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.30",
+            "avg_claim_similarity": "1.00",
+            "result_a": "Rats demonstrated fine orientation discrimination in both visual and tactile modalities, with sensitivity to 5\u00b0 angle differences in both modalities. This confirms that visual capacities of Long-Evans rats may be underestimated and demonstrates comparable tactile acuity using whiskers and snout.",
+            "result_b": "Rats can perform fine orientation discrimination using vision alone, touch alone, or both modalities together, with individual rats showing different modality-specific acuities but all performing better when both modalities are available.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "In both modalities rats were sensitive to 5\u00b0 angle differences.",
+                "claim_b": "In both modalities rats were sensitive to 5\u00b0 angle differences.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats were able to perform fine orientation discriminations in the purely visual (V) condition, confirming that the visual capacities of Long-Evans rats might be widely underestimated.",
+                "claim_b": "Rats were able to perform fine orientation discriminations in the purely visual (V) condition, confirming that the visual capacities of Long-Evans rats might be widely underestimated.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "In the purely tactile (T) condition, rats were also able to perform fine orientation discriminations using their snout and whiskers.",
+                "claim_b": "In the purely tactile (T) condition, rats were also able to perform fine orientation discriminations using their snout and whiskers.",
+                "similarity": "1.00"
+              }
+            ]
+          },
+          {
+            "ids": "R23 \u2194 R16",
+            "result_similarity": "0.70",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "4 (A) / 13 (B)",
+            "n_matched_claims": 4,
+            "claim_set_jaccard": "0.31",
+            "avg_claim_similarity": "0.55",
+            "result_a": "Previous multisensory studies have used arbitrary cross-modal associations. Vision and touch likely evolved together to explore spatial properties of the environment, and rodents may need to navigate oriented structures whether seen or felt. The brain's capacity for modality-independent object knowledge requires processing stages where information is encoded by multiple channels, and PPC contributes to this abstraction.",
+            "result_b": "The study builds on established knowledge about multisensory integration, PPC anatomy and function, and cross-modal cortical interactions from prior literature.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "The brain's capacity to call up knowledge about things independently of sensory input channel requires a stage of processing in which the same information is encoded by both channels, and PPC seems to contribute to this abstraction of stimuli from sensory domains.",
+                "claim_b": "The brain's capacity to call up knowledge about things independently of sensory input channel requires a stage of processing in which the same information is encoded by both channels.",
+                "similarity": "0.81"
+              },
+              {
+                "claim_a": "Numerous studies have trained subjects to associate the sensory data originating in two modalities by some arbitrary rule.",
+                "claim_b": "Primate PPC receives input from cortical areas representing multiple sensory modalities and communicates back to these territories.",
+                "similarity": "0.53"
+              },
+              {
+                "claim_a": "A rodent might need to maneuver through oriented bars, whether those bars are seen or felt.",
+                "claim_b": "Humans, non-human primates, and rodents demonstrate heightened accuracy of perceptual judgements when multiple cues are combined.",
+                "similarity": "0.43"
+              },
+              {
+                "claim_a": "Vision and touch have likely evolved together to explore the shape, form, and spatial properties of the environment.",
+                "claim_b": "PPC is a good candidate for visual-tactile convergence.",
+                "similarity": "0.41"
+              }
+            ]
+          },
+          {
+            "ids": "R6 \u2194 R5",
+            "result_similarity": "0.67",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "6 (A) / 1 (B)",
+            "n_matched_claims": 1,
+            "claim_set_jaccard": "0.17",
+            "avg_claim_similarity": "0.91",
+            "result_a": "Supralinear VT performance persisted in block design sessions (where modalities were not interleaved), with measured \u03c3VT values remaining close to or better than Bayesian optimal estimates. Response times were similar across modalities and longer for difficult trials (near 45\u00b0 boundary), arguing against motivational confounds or premature evidence truncation on unimodal trials.",
+            "result_b": "Supralinear combination persisted in block design experiments where modality conditions were not interleaved.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Comparing across sessions, rats still combined V and T signals in a supralinear fashion in block design sessions.",
+                "claim_b": "Comparing across sessions, rats still combined V and T signals in a supralinear fashion to guide VT performance in block design experiments.",
+                "similarity": "0.91"
+              }
+            ]
+          },
+          {
+            "ids": "R20 \u2194 R2",
+            "result_similarity": "0.65",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "4 (A) / 11 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.15",
+            "avg_claim_similarity": "0.48",
+            "result_a": "Prior psychophysical studies show that humans, non-human primates, and rodents demonstrate heightened accuracy when combining multiple cues, sometimes approaching optimal observer performance. PPC is anatomically positioned between primary sensory cortices and is a candidate for visual-tactile convergence, though the degree of multisensory convergence in rodent PPC is debated.",
+            "result_b": "Rats combined visual and tactile signals in a supralinear manner, exceeding predictions from a Bayesian ideal-observer model, with the greatest benefit at intermediate orientations.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Humans, non-human primates, and rodents demonstrate heightened accuracy of perceptual judgements when multiple cues are combined.",
+                "claim_b": "In the majority of rats the signals carried by the two sensory channels were not merged independently but were combined in a synergistic manner.",
+                "similarity": "0.51"
+              },
+              {
+                "claim_a": "The degree of multisensory convergence within PPC in rodents is debated.",
+                "claim_b": "9 out of 12 rats combined V and T signals in a supralinear manner.",
+                "similarity": "0.45"
+              }
+            ]
+          },
+          {
+            "ids": "R9 \u2194 R11",
+            "result_similarity": "0.55",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "5 (A) / 3 (B)",
+            "n_matched_claims": 1,
+            "claim_set_jaccard": "0.14",
+            "avg_claim_similarity": "0.59",
+            "result_a": "Single neurons in PPC exhibited nearly identical responses under V, T, and VT conditions. Across 622 neurons, firing rates were highly correlated between modalities (Pearson R=0.96-0.99 across orientations), with points clustering near the diagonal in V vs T plots, demonstrating supramodal coding.",
+            "result_b": "The PPC population code was supramodal, as demonstrated by successful cross-modality decoding where classifiers trained on one modality could predict behavior on different modalities, with signals paralleling behavioral performance across conditions.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Single neurons in PPC exhibited identical responses under the three modality conditions (V, T, and VT).",
+                "claim_b": "The orientation and category signal carried by neurons in the three modality conditions could not be distinguished except by its greater robustness in VT trials.",
+                "similarity": "0.59"
+              }
+            ]
+          },
+          {
+            "ids": "R2 \u2194 R4",
+            "result_similarity": "0.52",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "10 (A) / 6 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.14",
+            "avg_claim_similarity": "0.55",
+            "result_a": "Rats showed individual differences in modality-specific acuity (some better at V, others at T), but all rats performed significantly better in the VT condition than in either unimodal condition. VT performance showed reduced \u03c3 (p<0.001), reduced lapse rates (p=0.000), and more accurate boundary detection (PSE closer to 45\u00b0, p<0.02) compared to V and T conditions.",
+            "result_b": "Response times were longer for difficult trials near the category boundary and similar across modality conditions, indicating rats did not differentially truncate evidence accumulation based on trial difficulty or modality.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats showed a more accurate detection of the horizontal and vertical boundary in VT condition, assessed by the point of subjective equality (PSE closer to 45\u00b0, p < 0.02 for V and T in average curve compared to VT).",
+                "claim_b": "In all modality conditions, rats' response time was nearly 150 ms longer on trials with orientation near the 45\u00b0 category boundary.",
+                "similarity": "0.60"
+              },
+              {
+                "claim_a": "Rats 12 and 1 performed better in the V condition.",
+                "claim_b": "The rats seemed to try to acquire additional evidence on difficult trials rather than undersampling them.",
+                "similarity": "0.49"
+              }
+            ]
+          }
+        ],
+        "unmatched_a": [
+          "Multisensory benefit varied with stimulus orientation: no benefit at 45\u00b0 (category boundary where performance is at chance), limited benefit at cardinal orientations (0\u00b0 and 90\u00b0 where unimodal performance was already high), and greatest benefit at intermediate orientations (20\u00b0-35\u00b0 and 55\u00b0-70\u00b0).",
+          "The majority of rats (9/12 by Bayesian analysis, 8/12 by mutual information analysis) combined V and T signals in a supralinear manner, exceeding predictions from optimal linear combination of independent sensory channels. The two analytical approaches were correlated (R=0.6), providing converging evidence for synergistic multisensory integration.",
+          "Response times ranged from 435-734 ms (interquartile range) and were nearly 150 ms longer for orientations near the 45\u00b0 category boundary compared to cardinal orientations.",
+          "The orientation and category signals in PPC neurons were indistinguishable across modalities except for greater robustness in VT trials (mirroring behavioral performance). Individual neurons showed a continuum from orientation tuning to category tuning, with graded firing within categories or large steps at the 45\u00b0 boundary.",
+          "Evidence from mouse studies shows that auditory cortex activation can drive GABAergic inhibition in primary visual cortex and sharpen orientation selectivity of V1 neurons, supporting the possibility of cross-modal cortical interactions.",
+          "Primate PPC receives input from multiple sensory modalities and projects back to these areas. Rat PPC is considered homologous to primate PPC based on shared reciprocal connectivity with sensory, frontal, temporal, and limbic regions, positioning it to receive unimodal signals and transmit processed information downstream.",
+          "A previous study (Polley et al. 2005) showed that rats could learn whisker-dependent orientation discrimination in a single trial with resolution on the order of 45\u00b0.",
+          "Twelve male Long-Evans rats (8 weeks old, ~250g at arrival, growing to >600g) were used. They were maintained on 12/12 hr light/dark cycle with experiments during light phase, received 17-22 mL diluted pear juice as reward per session, and all protocols were approved by SISSA Ethics Committee and Italian Health Ministry."
+        ],
+        "unmatched_b": [
+          "Supramodal coding may arise from simultaneous arrival of congruent signals about real objects, reflecting ecological statistics and evolutionary co-development of vision and touch."
+        ]
+      }
+    },
+    {
+      "label_a": "pymupdf4llm",
+      "label_b": "unsegmented",
+      "n_results_a": 24,
+      "n_results_b": 11,
+      "avg_result_similarity": 0.7981,
+      "result_match_rate": 0.4583,
+      "evaluation_type_agreement": 1.0,
+      "result_type_agreement": 0.8182,
+      "avg_claim_set_jaccard": 0.5978,
+      "avg_claim_similarity": 0.868,
+      "distribution_a": {
+        "evaluation_type": {
+          "SUPPORTED": 21,
+          "UNCERTAIN": 3
+        },
+        "result_type": {
+          "MINOR": 12,
+          "MAJOR": 12
+        }
+      },
+      "distribution_b": {
+        "evaluation_type": {
+          "SUPPORTED": 8,
+          "UNCERTAIN": 3
+        },
+        "result_type": {
+          "MAJOR": 6,
+          "MINOR": 5
+        }
+      },
+      "summary": {
+        "pair": "pymupdf4llm \u2194 unsegmented",
+        "metrics": {
+          "results": "24 vs 11",
+          "matched_pairs": 11,
+          "unmatched_a": 13,
+          "unmatched_b": 0,
+          "result_level": {
+            "avg_result_similarity": "79.8%",
+            "result_match_rate": "45.8%",
+            "evaluation_type_agreement": "100.0%",
+            "result_type_agreement": "81.8%"
+          },
+          "claim_set_level": {
+            "avg_claim_set_jaccard": "59.8%",
+            "avg_claim_similarity": "86.8%"
+          }
+        },
+        "evaluation_type_distribution": {
+          "SUPPORTED": {
+            "pymupdf4llm": 21,
+            "unsegmented": 8
+          },
+          "UNCERTAIN": {
+            "pymupdf4llm": 3,
+            "unsegmented": 3
+          }
+        },
+        "result_type_distribution": {
+          "MAJOR": {
+            "pymupdf4llm": 12,
+            "unsegmented": 6
+          },
+          "MINOR": {
+            "pymupdf4llm": 12,
+            "unsegmented": 5
+          }
+        },
+        "matched_pairs": [
+          {
+            "ids": "R21 \u2194 R9",
+            "result_similarity": "0.91",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "3 (A) / 3 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "1.00",
+            "avg_claim_similarity": "0.96",
+            "result_a": "Primate PPC receives input from multiple sensory modalities and projects back to these areas. Rat PPC is considered homologous to primate PPC based on shared reciprocal connectivity with sensory, frontal, temporal, and limbic regions, positioning it to receive unimodal signals and transmit processed information downstream.",
+            "result_b": "Rat PPC is anatomically positioned to integrate multisensory information, receiving input from multiple sensory cortices and sharing reciprocal connectivity patterns with primate PPC.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Primate PPC receives input from cortical areas representing multiple sensory modalities and communicates back to these territories.",
+                "claim_b": "Primate PPC receives input from cortical areas representing multiple sensory modalities and communicates back to these territories.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "PPC in rats is held to be homologous to primate PPC, as it shares the characteristic reciprocal connectivity with sensory, frontal, temporal, and limbic cortical regions.",
+                "claim_b": "PPC in rats is held to be homologous to primate PPC, as it shares the characteristic reciprocal connectivity with sensory, frontal, temporal, and limbic cortical regions.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "PPC is well positioned to receive unimodal sensory signals and transmit a processed form of those signals to downstream cortical regions.",
+                "claim_b": "PPC is well positioned to receive unimodal sensory signals.",
+                "similarity": "0.89"
+              }
+            ]
+          },
+          {
+            "ids": "R12 \u2194 R6",
+            "result_similarity": "0.90",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "10 (A) / 5 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "0.95",
+            "result_a": "A linear discriminant classifier trained on PPC population activity (300 ms before response) achieved >90% accuracy in predicting rat choices (91-99% in 9/10 sessions, 70% in 1 session, p<0.001). Decoder performance was ~50% before trial onset (indicating no pre-stimulus bias) and increased to >90% by 250 ms before response. Almost all neurons contributed non-zero weights. The classifier replicated behavioral psychometric curves across modalities using cross-modality training, demonstrating supramodal population coding.",
+            "result_b": "A linear classifier trained on PPC population activity decoded the rat's choices with 91-99% accuracy (9/10 sessions), with nearly all neurons contributing non-zero weights. Cross-modality decoding demonstrated the population code was supramodal and could account for behavior.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "When tested, the classifier replicated the rat's behavior on over 90% of trials.",
+                "claim_b": "When tested, the classifier replicated the rat's behavior on over 90% of trials.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Almost all neuronal weights were non-zero in each session, indicating that every neuron in the population contributed to the classifier's performance.",
+                "claim_b": "Almost all neuronal weights were non-zero in each session, indicating that every neuron in the population contributed to the classifier's performance.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Across different modalities, the signal carried by the PPC population closely paralleled behavior.",
+                "claim_b": "The signal carried by the PPC population closely paralleled behavior across different modalities.",
+                "similarity": "0.99"
+              },
+              {
+                "claim_a": "Peak decoder performance measured in 5 rats ranged from 91% to 99% (9 sessions), with 1 session at 70% (p < 0.001, permutation test).",
+                "claim_b": "Peak decoder performance measured in 5 rats ranged from 91% to 99% (9 sessions), with 1 session at 70% (p < 0.001).",
+                "similarity": "0.99"
+              },
+              {
+                "claim_a": "Since for each trial the classifier was trained using only trials with modality different from the test trial, we can conclude that the population code was supramodal and could account for the rats' behavior.",
+                "claim_b": "The population code was supramodal and could account for the rats' behavior.",
+                "similarity": "0.76"
+              }
+            ]
+          },
+          {
+            "ids": "R1 \u2194 R1",
+            "result_similarity": "0.90",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "6 (A) / 10 (B)",
+            "n_matched_claims": 4,
+            "claim_set_jaccard": "0.33",
+            "avg_claim_similarity": "0.81",
+            "result_a": "Rats were trained to categorize grating orientations into two categories (0\u00b0\u00b145\u00b0 as horizontal and 90\u00b0\u00b145\u00b0 as vertical) using a visual-tactile discrimination task with randomly interleaved V, T, and VT trials (32% each) plus 4% control trials. The stimulus was a circular grating (98 mm diameter) with raised parallel bars (3.5 mm width and depth) alternately colored white and black.",
+            "result_b": "Rats successfully learned to categorize grating orientations (0-45\u00b0 as horizontal, 45-90\u00b0 as vertical) using visual, tactile, or combined visual-tactile cues. They immediately generalized this rule to novel orientations, suggesting they categorized based on deviation from cardinal orientations rather than memorizing specific angles.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats were trained to categorize orientations in the range of 0\u00b0\u201345\u00b0 as horizontal, and orientations in the range of 45\u00b0\u201390\u00b0 as vertical.",
+                "claim_b": "Rats were trained to categorize orientations from 0 to 45\u00b0 as horizontal and orientations from 45 to 90\u00b0 as vertical.",
+                "similarity": "0.98"
+              },
+              {
+                "claim_a": "The discriminandum had a circular boundary (98 mm diameter) and raised parallel bars.",
+                "claim_b": "The discriminandum had a circular boundary (98 mm diameter) and raised parallel bars (width and depth of 3.5 mm), alternately colored white and black.",
+                "similarity": "0.92"
+              },
+              {
+                "claim_a": "Rats learned to recognize two categories of orientation: 0\u00b0 \u00b1 45\u00b0 (''horizontal'') and 90\u00b0 \u00b1 45\u00b0 (''vertical'').",
+                "claim_b": "Rats solved the task by measuring the difference between the encountered orientation and the cardinal orientations of 'horizontal' and 'vertical'.",
+                "similarity": "0.85"
+              },
+              {
+                "claim_a": "The three stimulus conditions (V, T, and VT) were randomly interleaved with 32% likelihood per trial.",
+                "claim_b": "All three example rats performed better in the VT condition than in V or T alone.",
+                "similarity": "0.51"
+              }
+            ]
+          },
+          {
+            "ids": "R14 \u2194 R7",
+            "result_similarity": "0.85",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "3 (A) / 3 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "1.00",
+            "avg_claim_similarity": "0.98",
+            "result_a": "Rats demonstrated fine orientation discrimination in both visual and tactile modalities, with sensitivity to 5\u00b0 angle differences in both modalities. This confirms that visual capacities of Long-Evans rats may be underestimated and demonstrates comparable tactile acuity using whiskers and snout.",
+            "result_b": "Rats demonstrated fine orientation discrimination in both visual-only and tactile-only conditions, with sensitivity to 5\u00b0 angle differences in both modalities.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "In both modalities rats were sensitive to 5\u00b0 angle differences.",
+                "claim_b": "In both modalities rats were sensitive to 5\u00b0 angle differences.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "In the purely tactile (T) condition, rats were also able to perform fine orientation discriminations using their snout and whiskers.",
+                "claim_b": "In the purely tactile (T) condition, rats were able to perform fine orientation discriminations using their snout and whiskers.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats were able to perform fine orientation discriminations in the purely visual (V) condition, confirming that the visual capacities of Long-Evans rats might be widely underestimated.",
+                "claim_b": "Rats were able to perform fine orientation discriminations in the purely visual (V) condition.",
+                "similarity": "0.95"
+              }
+            ]
+          },
+          {
+            "ids": "R19 \u2194 R11",
+            "result_similarity": "0.79",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "4 (A) / 5 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "0.96",
+            "result_a": "A previous study (Raposo et al. 2014) found that PPC neurons showed modality selectivity when rats judged quantities of auditory/visual pulses, contrasting with the modality-free coding observed here. The authors hypothesize that supramodal coding arises from simultaneous arrival of congruous signals about a real object, which may better reflect natural statistics.",
+            "result_b": "Supramodal coding in PPC may arise from simultaneous arrival of congruent signals about real objects through multiple sensory channels, reflecting ecological statistics and enabling modality-independent object knowledge.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "We hypothesize that supramodal coding is a consequence of the nearly simultaneous arrival in PPC of congruous signals, through two sensory channels, about a real object.",
+                "claim_b": "Supramodal coding is a consequence of the nearly simultaneous arrival in PPC of congruous signals, through two sensory channels, about a real object.",
+                "similarity": "0.97"
+              },
+              {
+                "claim_a": "Coherence between modalities, as in our study, might better reflect the statistics of the real world.",
+                "claim_b": "Coherence between modalities might better reflect the statistics of the real world.",
+                "similarity": "0.96"
+              },
+              {
+                "claim_a": "In a recent study in which rats judged the quantities of auditory and/or visual pulses in a train, many neurons in PPC responded differentially on trials of the two modalities; indeed, modality itself could be decoded from neuronal firing.",
+                "claim_b": "In a recent study in which rats judged the quantities of auditory and/or visual pulses in a train, many neurons in PPC responded differentially on trials of the two modalities.",
+                "similarity": "0.95"
+              }
+            ]
+          },
+          {
+            "ids": "R17 \u2194 R8",
+            "result_similarity": "0.76",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "9 (A) / 6 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "0.82",
+            "result_a": "Supralinear multisensory integration has been reported previously and could arise from partial exploitation of unimodal information due to reduced motivation, or from violation of channel independence assumptions. Possible mechanisms include cross-modal sensorimotor interactions (e.g., vision guiding whisker palpation) or cortical synergy (e.g., cross-modal inhibition reducing noise in sensory representations).",
+            "result_b": "The observed supralinear integration may result from violation of the independence assumption in Bayesian models, potentially through sensorimotor interactions (visual guidance of whisking) or cross-modal cortical inhibition that suppresses noise.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Inhibition between cortical regions could allow activity evoked through one modality to suppress the non-specific noise in the other modality's stimulus representation.",
+                "claim_b": "Inhibition between cortical regions could allow activity evoked through one modality to suppress the non-specific noise in the other modality's stimulus representation.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The visual cue might help the rat palpate the surface with its whiskers more efficiently, boosting the tactile signal.",
+                "claim_b": "The visual cue might help the rat palpate the surface with its whiskers more efficiently, boosting the tactile signal.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Supralinear behavioral combination of sensory channels has been found in previous studies.",
+                "claim_b": "Supralinear behavioral combination of sensory channels has been found in previous studies.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Both cue-combination models employed in our study (Bayesian decision theory and MI) assume independence of the sensory channels.",
+                "claim_b": "The observed supralinearity could result from a violation of the assumption of independence of sensory channels.",
+                "similarity": "0.71"
+              },
+              {
+                "claim_a": "A second possible form of interaction is synergy between the two processing pathways within cortex.",
+                "claim_b": "In the mouse, activation of auditory cortex by a noise burst drives local GABAergic inhibition in the primary visual cortex, via cortico-cortical connections.",
+                "similarity": "0.41"
+              }
+            ]
+          },
+          {
+            "ids": "R8 \u2194 R4",
+            "result_similarity": "0.76",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "8 (A) / 14 (B)",
+            "n_matched_claims": 8,
+            "claim_set_jaccard": "0.57",
+            "avg_claim_similarity": "0.88",
+            "result_a": "PPC neurons showed task-related activity with two main response profiles: some neurons showed graded orientation tuning (firing rate modulated progressively from 0\u00b0 to 90\u00b0), while others showed categorical tuning (large firing rate changes at the 45\u00b0 boundary with poor modulation within categories). Neuronal responses were similar across V, T, and VT modality conditions.",
+            "result_b": "PPC neurons showed modality-invariant responses across visual, tactile, and visual-tactile conditions. Only 5% (30/622) of neurons were selective for stimulus modality, while firing rates were highly correlated (R=0.96-0.99) across modalities for different stimulus orientations.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Similar temporal profiles characterized V, T, and VT trials for the example neuron.",
+                "claim_b": "Similar temporal profiles characterized V, T, and VT trials for the example neuron.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The neuron had a stable firing rate of about 2 spikes/s as the rat awaited the trial onset.",
+                "claim_b": "The neuron had a stable firing rate of about 2 spikes/s as the rat awaited the trial onset.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The category-selective neurons were poorly modulated by stimulus orientation within a choice category.",
+                "claim_b": "The category-selective neurons were poorly modulated by stimulus orientation within a choice category.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "About 200 ms after trial onset, the neuron's firing rate ramped upward and remained at about 8 spikes/s until 1 s after trial onset.",
+                "claim_b": "About 200 ms after trial onset, the neuron's firing rate ramped upward and remained at about 8 spikes/s until 1 s after trial onset.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Two neurons carried a large signal about stimulus category, with firing rates deviating according to the upcoming action (left or right).",
+                "claim_b": "Two example neurons carried a large signal about stimulus category, with firing rates deviating according to the upcoming action (left or right).",
+                "similarity": "0.95"
+              },
+              {
+                "claim_a": "The first example neuron's firing rate was modulated by stimulus orientation, firing at a progressively higher rate as angle increased from 0\u00b0 to 90\u00b0.",
+                "claim_b": "The first example neuron fired at a progressively higher rate as angle increased from 0 to 90\u00b0.",
+                "similarity": "0.90"
+              },
+              {
+                "claim_a": "The second example neuron's firing rate was modulated by stimulus orientation, firing at a progressively lower rate from 0\u00b0 to 90\u00b0.",
+                "claim_b": "Neuronal firing was largely invariant to differences in modality for orientation-coding and category-coding neurons.",
+                "similarity": "0.67"
+              },
+              {
+                "claim_a": "PPC carried both graded information about object orientation and categorical information about the rat's upcoming choice.",
+                "claim_b": "The population of neurons did not appear to be informative about the modality of the stimulus but instead generated a robust signal about stimulus properties\u2014orientation and the choice category associated with that orientation\u2014irrespective of modality.",
+                "similarity": "0.49"
+              }
+            ]
+          },
+          {
+            "ids": "R10 \u2194 R5",
+            "result_similarity": "0.75",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "4 (A) / 7 (B)",
+            "n_matched_claims": 4,
+            "claim_set_jaccard": "0.57",
+            "avg_claim_similarity": "0.82",
+            "result_a": "Only 5% (30/622) of PPC neurons showed significant modality selectivity (p<0.01), while over 50% (318/622) showed significant category selectivity (p<0.01). Among category-selective neurons, more preferred rightward choices (219/318), suggesting contralateral preference in left PPC. The population encoded stimulus properties (orientation and category) irrespective of modality.",
+            "result_b": "Over 50% of PPC neurons (318/622) encoded the rat's upcoming choice, with 38% (239/622) carrying significant information about both stimulus orientation and choice category. The joint encoding suggests PPC participates in stimulus-to-category transformation.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "A greater number of neurons (219 out of 318 neurons) was selective for turns to the right (index < 0) than to the left (index > 0), suggesting overall opposite-side preference in left PPC.",
+                "claim_b": "A greater number of neurons (219 out of 318 neurons) was selective for turns to the right (index < 0) than to the left (index > 0), suggesting overall opposite-side preference in left PPC.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Over 50% of neurons (318 out of 622) were significantly selective (p < 0.01; permutation test) for the upcoming choice of the rat.",
+                "claim_b": "Over 50% of neurons (318 out of 622) were significantly selective (p < 0.01) for the upcoming choice of the rat.",
+                "similarity": "0.93"
+              },
+              {
+                "claim_a": "This population of neurons did not appear to be informative about the modality of the stimulus but instead generated a robust signal about stimulus properties\u2014orientation and the choice category associated with that orientation\u2014irrespective of modality.",
+                "claim_b": "About 38% of neurons (239 out of 622, p < 0.01) carried significant conditional information about both orientation and choice.",
+                "similarity": "0.74"
+              },
+              {
+                "claim_a": "Just 5% (30 out of 622) of PPC neurons were selective (p < 0.01; permutation test) for stimulus modality.",
+                "claim_b": "About 45% of neurons (284 out of 622, p < 0.01) carried significant information about stimulus angle conditional upon perceived category.",
+                "similarity": "0.61"
+              }
+            ]
+          },
+          {
+            "ids": "R4 \u2194 R3",
+            "result_similarity": "0.74",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "4 (A) / 5 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.29",
+            "avg_claim_similarity": "0.60",
+            "result_a": "Rats immediately generalized the categorization rule to novel orientations (90\u00b0-135\u00b0 and -45\u00b0 to 0\u00b0) in the first test session, performing equally well on new versus familiar stimuli (p>0.29 for all rats). This suggests rats solved the task by measuring angular distance from cardinal orientations rather than memorizing specific stimulus-reward associations.",
+            "result_b": "Response times increased by ~150 ms for orientations near the 45\u00b0 category boundary compared to cardinal orientations, and were similar across modality conditions, suggesting rats accumulated additional evidence on difficult trials rather than truncating processing.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "In ten rats who were well trained with stimuli in the range of 0\u00b0\u201390\u00b0, trials with stimulus orientations ranging from 90\u00b0\u2013135\u00b0 and \u221245\u00b0 to 0\u00b0 were introduced.",
+                "claim_b": "In all modality conditions, rats' response time was nearly 150 ms longer on trials with orientation near the 45\u00b0 category boundary.",
+                "similarity": "0.69"
+              },
+              {
+                "claim_a": "In the first session with novel orientations, each rat performed equally well on the new versus the familiar stimuli (bootstrap test, all rats p > 0.29).",
+                "claim_b": "Rats seemed to try to acquire additional evidence on difficult trials rather than undersampling them.",
+                "similarity": "0.51"
+              }
+            ]
+          },
+          {
+            "ids": "R5 \u2194 R2",
+            "result_similarity": "0.72",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "7 (A) / 5 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.71",
+            "avg_claim_similarity": "0.76",
+            "result_a": "The majority of rats (9/12 by Bayesian analysis, 8/12 by mutual information analysis) combined V and T signals in a supralinear manner, exceeding predictions from optimal linear combination of independent sensory channels. The two analytical approaches were correlated (R=0.6), providing converging evidence for synergistic multisensory integration.",
+            "result_b": "Rats exhibited supralinear integration of visual and tactile signals, with 9/12 rats showing bimodal performance exceeding Bayesian optimal predictions based on unimodal thresholds, and 8/12 rats showing strongly supralinear integration by mutual information analysis.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "8 out of 12 rats combined V and T signals in a strongly supralinear manner based on mutual information analysis.",
+                "claim_b": "Eight out of 12 rats combined V and T signals in a strongly supralinear manner based on mutual information analysis.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "9 out of 12 rats combined V and T signals in a supralinear manner.",
+                "claim_b": "Nine out of 12 rats combined V and T signals in a supralinear manner.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "2 rats combined V and T signals in a linear manner.",
+                "claim_b": "Comparing across sessions, rats still combined V and T signals in a supralinear fashion in block design experiments.",
+                "similarity": "0.74"
+              },
+              {
+                "claim_a": "VT performance was better than that predicted by optimal linear combination of V and T signals, indicating synergy between sensory channels.",
+                "claim_b": "Performance with vision and touch together reveals synergy between the two channels.",
+                "similarity": "0.63"
+              },
+              {
+                "claim_a": "Two analyses\u2014Bayesian prediction of underlying threshold and MI\u2014both suggest that in the majority of rats the signals carried by the two sensory channels were not merged independently but were combined in a synergistic manner.",
+                "claim_b": "The majority of rats exhibited actual VT performance significantly better than that predicted by the standard Bayesian ideal-observer model.",
+                "similarity": "0.45"
+              }
+            ]
+          },
+          {
+            "ids": "R16 \u2194 R10",
+            "result_similarity": "0.71",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "3 (A) / 5 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.60",
+            "avg_claim_similarity": "1.00",
+            "result_a": "Tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet task demands. The arbitrary 45\u00b0 category boundary must also be learned. These observations suggest PPC functional properties are not hardwired but emerge through learning to solve task requirements.",
+            "result_b": "PPC neurons show task-dependent plasticity, with orientation tuning and category boundary representations emerging through learning to meet behavioral demands rather than being hardwired.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "While PPC could receive orientation-tuned signals from earlier stages of visual cortical processing, tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet specific behavioral demands.",
+                "claim_b": "While PPC could receive orientation-tuned signals from earlier stages of visual cortical processing, tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet specific behavioral demands.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The reward rule boundary of 45\u00b0 was set arbitrarily, and its neuronal correlate must also be generated to meet behavioral demands.",
+                "claim_b": "The reward rule boundary of 45\u00b0 was set arbitrarily, and its neuronal correlate must be generated to meet behavioral demands.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "These observations lead to the conclusion that the functional properties of PPC neurons are not hardwired but rather emerge through a learning process in order to solve the requirements of ongoing tasks.",
+                "claim_b": "The functional properties of PPC neurons are not hardwired but rather emerge through a learning process in order to solve the requirements of ongoing tasks.",
+                "similarity": "0.99"
+              }
+            ]
+          }
+        ],
+        "unmatched_a": [
+          "Rats showed individual differences in modality-specific acuity (some better at V, others at T), but all rats performed significantly better in the VT condition than in either unimodal condition. VT performance showed reduced \u03c3 (p<0.001), reduced lapse rates (p=0.000), and more accurate boundary detection (PSE closer to 45\u00b0, p<0.02) compared to V and T conditions.",
+          "Multisensory benefit varied with stimulus orientation: no benefit at 45\u00b0 (category boundary where performance is at chance), limited benefit at cardinal orientations (0\u00b0 and 90\u00b0 where unimodal performance was already high), and greatest benefit at intermediate orientations (20\u00b0-35\u00b0 and 55\u00b0-70\u00b0).",
+          "Supralinear VT performance persisted in block design sessions (where modalities were not interleaved), with measured \u03c3VT values remaining close to or better than Bayesian optimal estimates. Response times were similar across modalities and longer for difficult trials (near 45\u00b0 boundary), arguing against motivational confounds or premature evidence truncation on unimodal trials.",
+          "Response times ranged from 435-734 ms (interquartile range) and were nearly 150 ms longer for orientations near the 45\u00b0 category boundary compared to cardinal orientations.",
+          "Single neurons in PPC exhibited nearly identical responses under V, T, and VT conditions. Across 622 neurons, firing rates were highly correlated between modalities (Pearson R=0.96-0.99 across orientations), with points clustering near the diagonal in V vs T plots, demonstrating supramodal coding.",
+          "Conditional mutual information analysis revealed that ~50% of neurons (315/622) carried information about category conditional on angle, ~45% (284/622) carried information about angle conditional on category, and ~38% (239/622) carried both. 78% of dual-coding neurons clustered within \u00b10.05 bits of equal information, suggesting PPC is involved in supramodal stimulus-to-category transformation.",
+          "PPC is involved in supramodal processing of shape, contributing to the formation of a supramodal object representation and participating in percept-to-action transformation. However, this interpretation is based on correlational evidence; causal evidence would require perturbation experiments.",
+          "The orientation and category signals in PPC neurons were indistinguishable across modalities except for greater robustness in VT trials (mirroring behavioral performance). Individual neurons showed a continuum from orientation tuning to category tuning, with graded firing within categories or large steps at the 45\u00b0 boundary.",
+          "Evidence from mouse studies shows that auditory cortex activation can drive GABAergic inhibition in primary visual cortex and sharpen orientation selectivity of V1 neurons, supporting the possibility of cross-modal cortical interactions.",
+          "Prior psychophysical studies show that humans, non-human primates, and rodents demonstrate heightened accuracy when combining multiple cues, sometimes approaching optimal observer performance. PPC is anatomically positioned between primary sensory cortices and is a candidate for visual-tactile convergence, though the degree of multisensory convergence in rodent PPC is debated.",
+          "A previous study (Polley et al. 2005) showed that rats could learn whisker-dependent orientation discrimination in a single trial with resolution on the order of 45\u00b0.",
+          "Previous multisensory studies have used arbitrary cross-modal associations. Vision and touch likely evolved together to explore spatial properties of the environment, and rodents may need to navigate oriented structures whether seen or felt. The brain's capacity for modality-independent object knowledge requires processing stages where information is encoded by multiple channels, and PPC contributes to this abstraction.",
+          "Twelve male Long-Evans rats (8 weeks old, ~250g at arrival, growing to >600g) were used. They were maintained on 12/12 hr light/dark cycle with experiments during light phase, received 17-22 mL diluted pear juice as reward per session, and all protocols were approved by SISSA Ethics Committee and Italian Health Ministry."
+        ],
+        "unmatched_b": []
+      }
+    },
+    {
+      "label_a": "segmented",
+      "label_b": "unsegmented",
+      "n_results_a": 17,
+      "n_results_b": 11,
+      "avg_result_similarity": 0.7987,
+      "result_match_rate": 0.6471,
+      "evaluation_type_agreement": 1.0,
+      "result_type_agreement": 0.7273,
+      "avg_claim_set_jaccard": 0.4194,
+      "avg_claim_similarity": 0.8884,
+      "distribution_a": {
+        "evaluation_type": {
+          "SUPPORTED": 14,
+          "UNCERTAIN": 3
+        },
+        "result_type": {
+          "MAJOR": 9,
+          "MINOR": 8
+        }
+      },
+      "distribution_b": {
+        "evaluation_type": {
+          "SUPPORTED": 8,
+          "UNCERTAIN": 3
+        },
+        "result_type": {
+          "MAJOR": 6,
+          "MINOR": 5
+        }
+      },
+      "summary": {
+        "pair": "segmented \u2194 unsegmented",
+        "metrics": {
+          "results": "17 vs 11",
+          "matched_pairs": 11,
+          "unmatched_a": 6,
+          "unmatched_b": 0,
+          "result_level": {
+            "avg_result_similarity": "79.9%",
+            "result_match_rate": "64.7%",
+            "evaluation_type_agreement": "100.0%",
+            "result_type_agreement": "72.7%"
+          },
+          "claim_set_level": {
+            "avg_claim_set_jaccard": "41.9%",
+            "avg_claim_similarity": "88.8%"
+          }
+        },
+        "evaluation_type_distribution": {
+          "SUPPORTED": {
+            "segmented": 14,
+            "unsegmented": 8
+          },
+          "UNCERTAIN": {
+            "segmented": 3,
+            "unsegmented": 3
+          }
+        },
+        "result_type_distribution": {
+          "MAJOR": {
+            "segmented": 9,
+            "unsegmented": 6
+          },
+          "MINOR": {
+            "segmented": 8,
+            "unsegmented": 5
+          }
+        },
+        "matched_pairs": [
+          {
+            "ids": "R7 \u2194 R4",
+            "result_similarity": "0.93",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "6 (A) / 14 (B)",
+            "n_matched_claims": 6,
+            "claim_set_jaccard": "0.43",
+            "avg_claim_similarity": "0.85",
+            "result_a": "PPC neuronal responses were largely invariant to stimulus modality, with only 5% of neurons showing modality selectivity, while firing rates remained consistent across visual, tactile, and bimodal conditions.",
+            "result_b": "PPC neurons showed modality-invariant responses across visual, tactile, and visual-tactile conditions. Only 5% (30/622) of neurons were selective for stimulus modality, while firing rates were highly correlated (R=0.96-0.99) across modalities for different stimulus orientations.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Just 5% (30 out of 622) of neurons were selective (p < 0.01) for stimulus modality.",
+                "claim_b": "Just 5% (30 out of 622) of neurons were selective (p < 0.01) for stimulus modality.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Each neuron's firing rates were the same under the V, T, and VT conditions.",
+                "claim_b": "Each neuron's firing rates were the same under the V, T, and VT conditions.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "This population of neurons did not appear to be informative about the modality of the stimulus but instead generated a robust signal about stimulus properties-orientation and the choice category associated with that orientation-irrespective of modality.",
+                "claim_b": "The population of neurons did not appear to be informative about the modality of the stimulus but instead generated a robust signal about stimulus properties\u2014orientation and the choice category associated with that orientation\u2014irrespective of modality.",
+                "similarity": "0.99"
+              },
+              {
+                "claim_a": "While neuronal firing could vary according to orientation or category, it was largely invariant to differences in modality.",
+                "claim_b": "Neuronal firing was largely invariant to differences in modality for orientation-coding and category-coding neurons.",
+                "similarity": "0.89"
+              },
+              {
+                "claim_a": "The independence of firing rate on modality held across the six stimulus orientations.",
+                "claim_b": "The Pearson linear correlation coefficient, R, between firing rate on V and T trials ranged from 0.96 to 0.99 across six stimulus orientations.",
+                "similarity": "0.69"
+              },
+              {
+                "claim_a": "A given neuron's overall engagement in the task was nearly equal under the three modality conditions.",
+                "claim_b": "Two example neurons carried a large signal about stimulus category, with firing rates deviating according to the upcoming action (left or right).",
+                "similarity": "0.56"
+              }
+            ]
+          },
+          {
+            "ids": "R17 \u2194 R1",
+            "result_similarity": "0.85",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "2 (A) / 10 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.20",
+            "avg_claim_similarity": "0.99",
+            "result_a": "The experimental stimulus was a 98mm diameter circular grating with 3.5mm raised bars, and rats were trained to categorize orientations 0-45\u00b0 as horizontal and 45-90\u00b0 as vertical.",
+            "result_b": "Rats successfully learned to categorize grating orientations (0-45\u00b0 as horizontal, 45-90\u00b0 as vertical) using visual, tactile, or combined visual-tactile cues. They immediately generalized this rule to novel orientations, suggesting they categorized based on deviation from cardinal orientations rather than memorizing specific angles.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "The discriminandum had a circular boundary (98 mm diameter) and raised parallel bars (width and depth of 3.5 mm), alternately colored white and black.",
+                "claim_b": "The discriminandum had a circular boundary (98 mm diameter) and raised parallel bars (width and depth of 3.5 mm), alternately colored white and black.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats were trained to categorize orientations in the range of 0-45\u00b0 as horizontal, and orientations in the range of 45-90\u00b0 as vertical.",
+                "claim_b": "Rats were trained to categorize orientations from 0 to 45\u00b0 as horizontal and orientations from 45 to 90\u00b0 as vertical.",
+                "similarity": "0.99"
+              }
+            ]
+          },
+          {
+            "ids": "R15 \u2194 R11",
+            "result_similarity": "0.84",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "3 (A) / 5 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.60",
+            "avg_claim_similarity": "1.00",
+            "result_a": "Supramodal coding may arise from simultaneous arrival of congruent signals about real objects, reflecting ecological statistics and evolutionary co-development of vision and touch.",
+            "result_b": "Supramodal coding in PPC may arise from simultaneous arrival of congruent signals about real objects through multiple sensory channels, reflecting ecological statistics and enabling modality-independent object knowledge.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Coherence between modalities might better reflect the statistics of the real world.",
+                "claim_b": "Coherence between modalities might better reflect the statistics of the real world.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Vision and touch have likely evolved together to explore the shape, form, and spatial properties of the environment.",
+                "claim_b": "Vision and touch have likely evolved together to explore the shape, form, and spatial properties of the environment.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Supramodal coding is a consequence of the nearly simultaneous arrival in PPC of congruous signals, through two sensory channels, about a real object.",
+                "claim_b": "Supramodal coding is a consequence of the nearly simultaneous arrival in PPC of congruous signals, through two sensory channels, about a real object.",
+                "similarity": "1.00"
+              }
+            ]
+          },
+          {
+            "ids": "R10 \u2194 R6",
+            "result_similarity": "0.82",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "7 (A) / 5 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.71",
+            "avg_claim_similarity": "0.81",
+            "result_a": "A linear classifier trained on PPC population activity could predict rats' choices with >90% accuracy, with performance increasing from chance before stimulus onset to >90% by 250ms before response, and nearly all neurons contributing to classification.",
+            "result_b": "A linear classifier trained on PPC population activity decoded the rat's choices with 91-99% accuracy (9/10 sessions), with nearly all neurons contributing non-zero weights. Cross-modality decoding demonstrated the population code was supramodal and could account for behavior.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "When tested, the classifier replicated the rat's behavior on over 90% of trials.",
+                "claim_b": "When tested, the classifier replicated the rat's behavior on over 90% of trials.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Peak decoder performance measured in 5 rats ranged from 91% to 99% (9 sessions), with 1 session at 70% (p < 0.001).",
+                "claim_b": "Peak decoder performance measured in 5 rats ranged from 91% to 99% (9 sessions), with 1 session at 70% (p < 0.001).",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Almost all neuronal weights were non-zero in each session, indicating that every neuron in the population contributed to the classifier's performance.",
+                "claim_b": "Almost all neuronal weights were non-zero in each session, indicating that every neuron in the population contributed to the classifier's performance.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The classifier was able to determine a boundary that could separate the population's activity into two states associated with the rat's two choices.",
+                "claim_b": "The population code was supramodal and could account for the rats' behavior.",
+                "similarity": "0.57"
+              },
+              {
+                "claim_a": "This suggests that the PPC population did not manifest a choice bias before encountering the stimulus.",
+                "claim_b": "The signal carried by the PPC population closely paralleled behavior across different modalities.",
+                "similarity": "0.46"
+              }
+            ]
+          },
+          {
+            "ids": "R1 \u2194 R7",
+            "result_similarity": "0.80",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "10 (A) / 3 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.30",
+            "avg_claim_similarity": "0.98",
+            "result_a": "Rats can perform fine orientation discrimination using vision alone, touch alone, or both modalities together, with individual rats showing different modality-specific acuities but all performing better when both modalities are available.",
+            "result_b": "Rats demonstrated fine orientation discrimination in both visual-only and tactile-only conditions, with sensitivity to 5\u00b0 angle differences in both modalities.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "In both modalities rats were sensitive to 5\u00b0 angle differences.",
+                "claim_b": "In both modalities rats were sensitive to 5\u00b0 angle differences.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "In the purely tactile (T) condition, rats were also able to perform fine orientation discriminations using their snout and whiskers.",
+                "claim_b": "In the purely tactile (T) condition, rats were able to perform fine orientation discriminations using their snout and whiskers.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats were able to perform fine orientation discriminations in the purely visual (V) condition, confirming that the visual capacities of Long-Evans rats might be widely underestimated.",
+                "claim_b": "Rats were able to perform fine orientation discriminations in the purely visual (V) condition.",
+                "similarity": "0.95"
+              }
+            ]
+          },
+          {
+            "ids": "R8 \u2194 R5",
+            "result_similarity": "0.80",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "2 (A) / 7 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.29",
+            "avg_claim_similarity": "0.99",
+            "result_a": "Over 50% of PPC neurons showed significant selectivity for the rat's upcoming choice, with a bias toward contralateral (right) choices in left PPC.",
+            "result_b": "Over 50% of PPC neurons (318/622) encoded the rat's upcoming choice, with 38% (239/622) carrying significant information about both stimulus orientation and choice category. The joint encoding suggests PPC participates in stimulus-to-category transformation.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Over 50% of neurons (318 out of 622) were significantly selective (p < 0.01) for the upcoming choice of the rat.",
+                "claim_b": "Over 50% of neurons (318 out of 622) were significantly selective (p < 0.01) for the upcoming choice of the rat.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "A greater number of neurons (219 out of 318 neurons) was selective for turns to the right than to the left, suggesting overall opposite-side preference in left PPC.",
+                "claim_b": "A greater number of neurons (219 out of 318 neurons) was selective for turns to the right (index < 0) than to the left (index > 0), suggesting overall opposite-side preference in left PPC.",
+                "similarity": "0.98"
+              }
+            ]
+          },
+          {
+            "ids": "R14 \u2194 R10",
+            "result_similarity": "0.79",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "2 (A) / 5 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.40",
+            "avg_claim_similarity": "1.00",
+            "result_a": "Tactile orientation tuning may be generated in PPC rather than inherited from barrel cortex, and the arbitrary 45\u00b0 category boundary must be learned, suggesting task-dependent plasticity.",
+            "result_b": "PPC neurons show task-dependent plasticity, with orientation tuning and category boundary representations emerging through learning to meet behavioral demands rather than being hardwired.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "While PPC could receive orientation-tuned signals from earlier stages of visual cortical processing, tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet specific behavioral demands.",
+                "claim_b": "While PPC could receive orientation-tuned signals from earlier stages of visual cortical processing, tactile orientation tuning has not been reported in barrel cortex and may be generated in PPC to meet specific behavioral demands.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The reward rule boundary of 45\u00b0 was set arbitrarily, and its neuronal correlate must also be generated to meet behavioral demands.",
+                "claim_b": "The reward rule boundary of 45\u00b0 was set arbitrarily, and its neuronal correlate must be generated to meet behavioral demands.",
+                "similarity": "1.00"
+              }
+            ]
+          },
+          {
+            "ids": "R2 \u2194 R2",
+            "result_similarity": "0.78",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "11 (A) / 5 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.45",
+            "avg_claim_similarity": "0.83",
+            "result_a": "Rats combined visual and tactile signals in a supralinear manner, exceeding predictions from a Bayesian ideal-observer model, with the greatest benefit at intermediate orientations.",
+            "result_b": "Rats exhibited supralinear integration of visual and tactile signals, with 9/12 rats showing bimodal performance exceeding Bayesian optimal predictions based on unimodal thresholds, and 8/12 rats showing strongly supralinear integration by mutual information analysis.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "The majority of rats exhibited actual VT performance significantly better than that predicted by the standard Bayesian ideal-observer model.",
+                "claim_b": "The majority of rats exhibited actual VT performance significantly better than that predicted by the standard Bayesian ideal-observer model.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "8 out of 12 rats combined V and T signals in a strongly supralinear manner based on mutual information analysis.",
+                "claim_b": "Eight out of 12 rats combined V and T signals in a strongly supralinear manner based on mutual information analysis.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "9 out of 12 rats combined V and T signals in a supralinear manner.",
+                "claim_b": "Nine out of 12 rats combined V and T signals in a supralinear manner.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "In the VT condition, rats showed reduced lapse rates compared to V and T.",
+                "claim_b": "Comparing across sessions, rats still combined V and T signals in a supralinear fashion in block design experiments.",
+                "similarity": "0.60"
+              },
+              {
+                "claim_a": "In the majority of rats the signals carried by the two sensory channels were not merged independently but were combined in a synergistic manner.",
+                "claim_b": "Performance with vision and touch together reveals synergy between the two channels.",
+                "similarity": "0.57"
+              }
+            ]
+          },
+          {
+            "ids": "R13 \u2194 R8",
+            "result_similarity": "0.76",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "4 (A) / 6 (B)",
+            "n_matched_claims": 4,
+            "claim_set_jaccard": "0.67",
+            "avg_claim_similarity": "0.78",
+            "result_a": "Supralinear combination may result from violation of the independence assumption, potentially through behavioral strategies (visual guidance of tactile exploration) or neural mechanisms (cross-modal inhibition of noise).",
+            "result_b": "The observed supralinear integration may result from violation of the independence assumption in Bayesian models, potentially through sensorimotor interactions (visual guidance of whisking) or cross-modal cortical inhibition that suppresses noise.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "The visual cue might help the rat palpate the surface with its whiskers more efficiently, boosting the tactile signal.",
+                "claim_b": "The visual cue might help the rat palpate the surface with its whiskers more efficiently, boosting the tactile signal.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Inhibition between cortical regions could allow activity evoked through one modality to suppress the non-specific noise in the other modality's stimulus representation.",
+                "claim_b": "Inhibition between cortical regions could allow activity evoked through one modality to suppress the non-specific noise in the other modality's stimulus representation.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The observed supralinearity could result from a violation of the independence assumption - visual and tactile signals might not be processed independently in bimodal trials.",
+                "claim_b": "The observed supralinearity could result from a violation of the assumption of independence of sensory channels.",
+                "similarity": "0.70"
+              },
+              {
+                "claim_a": "Supralinear combination could occur if the information available on unimodal trials were only partially exploited, while the information available on bimodal trials were completely exploited.",
+                "claim_b": "Supralinear behavioral combination of sensory channels has been found in previous studies.",
+                "similarity": "0.43"
+              }
+            ]
+          },
+          {
+            "ids": "R3 \u2194 R3",
+            "result_similarity": "0.73",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "3 (A) / 5 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.33",
+            "avg_claim_similarity": "0.57",
+            "result_a": "Rats generalized the orientation categorization rule to novel stimuli immediately upon first presentation, suggesting they solved the task by measuring angular distance from cardinal orientations.",
+            "result_b": "Response times increased by ~150 ms for orientations near the 45\u00b0 category boundary compared to cardinal orientations, and were similar across modality conditions, suggesting rats accumulated additional evidence on difficult trials rather than truncating processing.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats seemed to solve the task by measuring the difference between the encountered orientation and the cardinal orientations of 'horizontal' and 'vertical.'",
+                "claim_b": "In all modality conditions, rats' response time was nearly 150 ms longer on trials with orientation near the 45\u00b0 category boundary.",
+                "similarity": "0.65"
+              },
+              {
+                "claim_a": "In the first session with novel orientations, each rat performed equally well on the new versus the familiar stimuli.",
+                "claim_b": "Rats seemed to try to acquire additional evidence on difficult trials rather than undersampling them.",
+                "similarity": "0.48"
+              }
+            ]
+          },
+          {
+            "ids": "R16 \u2194 R9",
+            "result_similarity": "0.68",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "13 (A) / 3 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.23",
+            "avg_claim_similarity": "0.96",
+            "result_a": "The study builds on established knowledge about multisensory integration, PPC anatomy and function, and cross-modal cortical interactions from prior literature.",
+            "result_b": "Rat PPC is anatomically positioned to integrate multisensory information, receiving input from multiple sensory cortices and sharing reciprocal connectivity patterns with primate PPC.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Primate PPC receives input from cortical areas representing multiple sensory modalities and communicates back to these territories.",
+                "claim_b": "Primate PPC receives input from cortical areas representing multiple sensory modalities and communicates back to these territories.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "PPC in rats is held to be homologous to primate PPC, as it shares the characteristic reciprocal connectivity with sensory, frontal, temporal, and limbic cortical regions.",
+                "claim_b": "PPC in rats is held to be homologous to primate PPC, as it shares the characteristic reciprocal connectivity with sensory, frontal, temporal, and limbic cortical regions.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "PPC is well positioned to receive unimodal sensory signals and transmit a processed form of those signals to downstream cortical regions.",
+                "claim_b": "PPC is well positioned to receive unimodal sensory signals.",
+                "similarity": "0.89"
+              }
+            ]
+          }
+        ],
+        "unmatched_a": [
+          "Response times were longer for difficult trials near the category boundary and similar across modality conditions, indicating rats did not differentially truncate evidence accumulation based on trial difficulty or modality.",
+          "Supralinear combination persisted in block design experiments where modality conditions were not interleaved.",
+          "Individual PPC neurons showed task-related firing patterns that encoded either stimulus orientation in a graded manner or stimulus category with sharp transitions at the boundary, with similar temporal profiles across modalities.",
+          "PPC neurons jointly encoded stimulus orientation and category through conditional information analysis, with 78% of informative neurons showing both types of coding distributed along a continuum, suggesting PPC participates in stimulus-to-category transformation.",
+          "The PPC population code was supramodal, as demonstrated by successful cross-modality decoding where classifiers trained on one modality could predict behavior on different modalities, with signals paralleling behavioral performance across conditions.",
+          "PPC contributes to forming supramodal object representations and participates in percept-to-action transformation, with functional properties emerging through learning rather than being hardwired."
+        ],
+        "unmatched_b": []
+      }
+    }
+  ]
+}

--- a/papers/eLife.66429/compare_results_report.json
+++ b/papers/eLife.66429/compare_results_report.json
@@ -1,0 +1,1048 @@
+{
+  "config": {
+    "runs": {
+      "unsegmented": "papers/eLife.66429/20260316_anthropic",
+      "segmented": "papers/eLife.66429/20260316_segmented_anthropic",
+      "pypdf4llm": "papers/eLife.66429/20260406_pypdf4llm_anthropic"
+    },
+    "result_threshold": 0.5,
+    "claim_threshold": 0.4,
+    "similarity_backend": "sentence-transformers"
+  },
+  "overall_summary": [
+    {
+      "pair": "unsegmented \u2194 segmented",
+      "avg_result_similarity": "73.3%",
+      "result_match_rate": "60.0%",
+      "evaluation_type_agreement": "83.3%",
+      "result_type_agreement": "83.3%",
+      "avg_claim_set_jaccard": "52.6%",
+      "avg_claim_similarity": "78.8%"
+    },
+    {
+      "pair": "unsegmented \u2194 pypdf4llm",
+      "avg_result_similarity": "78.0%",
+      "result_match_rate": "72.7%",
+      "evaluation_type_agreement": "87.5%",
+      "result_type_agreement": "87.5%",
+      "avg_claim_set_jaccard": "55.7%",
+      "avg_claim_similarity": "88.1%"
+    },
+    {
+      "pair": "segmented \u2194 pypdf4llm",
+      "avg_result_similarity": "82.7%",
+      "result_match_rate": "54.5%",
+      "evaluation_type_agreement": "83.3%",
+      "result_type_agreement": "100.0%",
+      "avg_claim_set_jaccard": "54.4%",
+      "avg_claim_similarity": "89.9%"
+    }
+  ],
+  "pairwise": [
+    {
+      "label_a": "unsegmented",
+      "label_b": "segmented",
+      "n_results_a": 10,
+      "n_results_b": 7,
+      "avg_result_similarity": 0.7331,
+      "result_match_rate": 0.6,
+      "evaluation_type_agreement": 0.8333,
+      "result_type_agreement": 0.8333,
+      "avg_claim_set_jaccard": 0.5264,
+      "avg_claim_similarity": 0.7877,
+      "distribution_a": {
+        "evaluation_type": {
+          "SUPPORTED": 9,
+          "UNCERTAIN": 1
+        },
+        "result_type": {
+          "MINOR": 5,
+          "MAJOR": 5
+        }
+      },
+      "distribution_b": {
+        "evaluation_type": {
+          "SUPPORTED": 7
+        },
+        "result_type": {
+          "MAJOR": 2,
+          "MINOR": 5
+        }
+      },
+      "summary": {
+        "pair": "unsegmented \u2194 segmented",
+        "metrics": {
+          "results": "10 vs 7",
+          "matched_pairs": 6,
+          "unmatched_a": 4,
+          "unmatched_b": 1,
+          "result_level": {
+            "avg_result_similarity": "73.3%",
+            "result_match_rate": "60.0%",
+            "evaluation_type_agreement": "83.3%",
+            "result_type_agreement": "83.3%"
+          },
+          "claim_set_level": {
+            "avg_claim_set_jaccard": "52.6%",
+            "avg_claim_similarity": "78.8%"
+          }
+        },
+        "evaluation_type_distribution": {
+          "SUPPORTED": {
+            "unsegmented": 9,
+            "segmented": 7
+          },
+          "UNCERTAIN": {
+            "unsegmented": 1,
+            "segmented": 0
+          }
+        },
+        "result_type_distribution": {
+          "MAJOR": {
+            "unsegmented": 5,
+            "segmented": 2
+          },
+          "MINOR": {
+            "unsegmented": 5,
+            "segmented": 5
+          }
+        },
+        "matched_pairs": [
+          {
+            "ids": "R1 \u2194 R2",
+            "result_similarity": "0.85",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "9 (A) / 15 (B)",
+            "n_matched_claims": 9,
+            "claim_set_jaccard": "0.60",
+            "avg_claim_similarity": "0.74",
+            "result_a": "The manuscript challenges the widespread assumption that rats are functionally blind under red light. This assumption is based on rats being dichromats lacking red cones, and prior ERG studies showing no significant response above 620 nm. However, conflicting evidence exists, with another study showing ERG responses to red light. Red light has been commonly used in behavioral experiments under the assumption it provides darkness for the animal.",
+            "result_b": "Prior literature establishes that rats are dichromatic with UV and green cones but lack red cones, have rod-dominated retinas, and show poor wavelength discrimination. Recent ERG studies show conflicting results regarding red light sensitivity, with one study finding no response above 620 nm and another finding significant responses to far-red light.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "No significant ERG response to long wavelength light (above 620 nm) was detected in Wistar rats.",
+                "claim_b": "No significant ERG response to long wavelength light (above 620 nm) was detected in Wistar rats.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Another study showed significant scotopic and photopic ERG responses to red light even at low intensities.",
+                "claim_b": "A study showed significant scotopic and photopic ERG responses to red light even at low intensities.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "ERG responses of photopic spectral sensitivity curves of photoreceptors of rats and mice identified two sensitivity peaks in Wistar rats: 362 and 502 nm.",
+                "claim_b": "ERG responses of photopic spectral sensitivity curves of photoreceptors of rats and mice were measured throughout the UV-visible spectrum (300-700 nm).",
+                "similarity": "0.95"
+              },
+              {
+                "claim_a": "Rats and mice are assumed to be functionally blind under red light.",
+                "claim_b": "From the inability to see red as a color, it does not necessarily follow that rodents cannot absorb red light through their rod-dominated retina to support form vision.",
+                "similarity": "0.77"
+              },
+              {
+                "claim_a": "Rats are dichromats who possess ultraviolet and green cones, but not red cones.",
+                "claim_b": "Rodents lack red cones.",
+                "similarity": "0.67"
+              },
+              {
+                "claim_a": "In a developmental study of the visual cortex, mice were dark-reared but were allowed very brief daily exposure to red light.",
+                "claim_b": "Both rat strains showed significant scotopic and photopic ERG responses to red light even at low intensities.",
+                "similarity": "0.66"
+              },
+              {
+                "claim_a": "Place-cell studies of rats navigating under dim red light have taken red light as the absence of visual input.",
+                "claim_b": "A recent study examined the retinal responses mediated by rods and cones of pigmented (Brown Norway) and albino (Wistar) rats in response to monochromatic far-red light of 656 \u00b1 10 nm in both photopic and scotopic settings.",
+                "similarity": "0.62"
+              },
+              {
+                "claim_a": "Rodent behavioral experiments done under red light are believed to place the animal in dark conditions while allowing the experimenter to observe the preparation directly or by video recording.",
+                "claim_b": "Rats are largely crepuscular and usually found in poorly illuminated environments during daylight.",
+                "similarity": "0.57"
+              },
+              {
+                "claim_a": "Red illumination is often used in reverse light cycle conditions in animal husbandry settings with the assumption that it will not affect rodent circadian rhythms.",
+                "claim_b": "Rats perform poorly in discriminating between nearby wavelengths, compared to humans.",
+                "similarity": "0.45"
+              }
+            ]
+          },
+          {
+            "ids": "R2 \u2194 R1",
+            "result_similarity": "0.83",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "7 (A) / 25 (B)",
+            "n_matched_claims": 7,
+            "claim_set_jaccard": "0.28",
+            "avg_claim_similarity": "0.99",
+            "result_a": "Long-Evans rats successfully performed visual orientation discrimination under red light (626 nm and 652 nm) with accuracy equivalent to white light (84-86% vs 87% correct). All four rats performed well under white LED illumination, and dark-adapted rats maintained this performance under red LEDs, demonstrating conserved visual capacity.",
+            "result_b": "Long-Evans rats retain substantial visual form discrimination capacity under red light (626 nm and 652 nm), with performance equivalent to white light, challenging the assumption of functional blindness. Performance degrades at 729 nm and approaches chance at infrared wavelengths (854 nm, 930 nm). The visual capacity under red light is attributed to absorption of red light by photoreceptors rather than spectral leakage from LEDs.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Average performance was 87 \u00b1 2% correct under white light.",
+                "claim_b": "Average performance was 87 \u00b1 2% correct under white light.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "All rats (N = 4) performed well under white LED illumination.",
+                "claim_b": "All rats (N = 4) performed well under white LED illumination.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Long-Evans rats can discriminate visual form under red light of various wavelength bands.",
+                "claim_b": "Long-Evans rats can discriminate visual form under red light of various wavelength bands.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Average performance was 86 \u00b1 2% under 652 nm (p=0.419 compared to white light).",
+                "claim_b": "Average performance was 86 \u00b1 2% under 652 nm (p=0.419 compared to white light).",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Average performance was 84 \u00b1 3% under 626 nm illumination (p=0.158 compared to white light).",
+                "claim_b": "Average performance was 84 \u00b1 3% under 626 nm illumination (p=0.158 compared to white light).",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Dark-adapted rats performed the visual categorization task under 626 nm and 652 nm LEDs with accuracy equivalent to that under white light.",
+                "claim_b": "Dark-adapted rats performed the visual categorization task under 626 nm and 652 nm LEDs with accuracy equivalent to that under white light.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats can distinguish between horizontal and vertical orientations of a black and white grating under red light.",
+                "claim_b": "Rats had to distinguish between horizontal and vertical orientations of a black and white grating.",
+                "similarity": "0.92"
+              }
+            ]
+          },
+          {
+            "ids": "R9 \u2194 R4",
+            "result_similarity": "0.74",
+            "evaluation_type_match": false,
+            "result_type_match": true,
+            "claims": "4 (A) / 7 (B)",
+            "n_matched_claims": 4,
+            "claim_set_jaccard": "0.57",
+            "avg_claim_similarity": "0.99",
+            "result_a": "The mechanisms underlying red light detection remain speculative. Possibilities include unconscious circadian entrainment, cross-retina population coding to amplify weak signals, or nonlinear processes like two-photon activation, though the latter is unlikely given the low light intensities used.",
+            "result_b": "The gap between physiological photoreceptor activation and behaviorally meaningful visual signals under red light had not been established. The study does not directly measure photoreceptor sensitivity but infers that mechanisms must exist to convert minimal receptor activation into functional signals. Two-photon activation is considered unlikely given the low light intensities used.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Photoreceptors could respond to longer wavelengths through a nonlinear optical process including two-photon activation of photopigments.",
+                "claim_b": "Photoreceptors could respond to longer wavelengths through a nonlinear optical process including two-photon activation of photopigments.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Red light might act to entrain circadian rhythms, unconscious to the animal.",
+                "claim_b": "Red light might act to entrain circadian rhythms, unconscious to the animal.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The sensitivity of mice is emphasized by the finding that red illumination delivered into the brain in an optogenetic protocol evoked a behavioral artifact in mice performing a visually guided discrimination task.",
+                "claim_b": "Red illumination delivered into the brain in an optogenetic protocol evoked a behavioral artifact in mice performing a visually guided discrimination task.",
+                "similarity": "0.98"
+              },
+              {
+                "claim_a": "The results indicate that mechanisms must exist for converting miniscule quantities of receptor activation into meaningful signals, perhaps through some cross-retina population code.",
+                "claim_b": "Mechanisms must exist for converting miniscule quantities of receptor activation into meaningful signals, perhaps through some cross-retina population code.",
+                "similarity": "0.98"
+              }
+            ]
+          },
+          {
+            "ids": "R7 \u2194 R3",
+            "result_similarity": "0.73",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "4 (A) / 4 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.60",
+            "avg_claim_similarity": "0.56",
+            "result_a": "The findings have important implications for experimental design: researchers should not assume red-light blindness in rodents, and illumination at 850 nm provides optimal conditions for vision-excluded studies while remaining detectable by standard cameras.",
+            "result_b": "Red light illumination is widely used in rodent behavioral research under the assumption that it creates functionally dark conditions while allowing experimenter observation, including in place-cell studies, developmental studies, and animal husbandry settings.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Investigations aiming to explore rodent physiological and behavioral functions in the absence of visual input should not assume red-light blindness.",
+                "claim_b": "Rodent behavioral experiments done under red light are believed to place the animal in dark conditions while allowing the experimenter to observe the preparation directly or by video recording.",
+                "similarity": "0.72"
+              },
+              {
+                "claim_a": "Behaviors may be documented by video while the animal performs without visual cues at 850 nm illumination.",
+                "claim_b": "Place-cell studies of rats navigating under dim red light have been conducted, taken as the absence of visual input.",
+                "similarity": "0.51"
+              },
+              {
+                "claim_a": "In all of these cases, the animals may acquire more visual input than previously believed.",
+                "claim_b": "In a developmental study of the visual cortex, mice were dark-reared but were allowed very brief daily exposure to red light.",
+                "similarity": "0.45"
+              }
+            ]
+          },
+          {
+            "ids": "R10 \u2194 R6",
+            "result_similarity": "0.68",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "6 (A) / 7 (B)",
+            "n_matched_claims": 6,
+            "claim_set_jaccard": "0.86",
+            "avg_claim_similarity": "0.92",
+            "result_a": "The study extends the range of visual perceptual functions for which rats serve as models, characterizing orientation discrimination across wavelengths. This has implications for experimental design and animal welfare in laboratory settings.",
+            "result_b": "Rats are increasingly used as models for visual perception research, demonstrating sophisticated visual capacities including view-invariant object recognition through accessible neural circuits. The present study extends understanding of rat visual capabilities and has implications for experimental design and animal welfare.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats achieve high-level sensory-perceptual cognition through the workings of neuronal circuits that are accessible.",
+                "claim_b": "Rats achieve high-level sensory-perceptual cognition through the workings of neuronal circuits that are accessible.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "A complete understanding of the visual processing of these animals is important not only in the design and control of the behavioral and physiological experiments but also to ensure optimal environmental lighting conditions for their well-being in laboratory settings.",
+                "claim_b": "A complete understanding of the visual processing of these animals is important not only in the design and control of the behavioral and physiological experiments but also to ensure optimal environmental lighting conditions for their well-being in laboratory settings.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "There is growing interest in the use of rodents for the study of vision, alone or combined with other modalities.",
+                "claim_b": "There is growing interest in the use of rodents for the study of vision, alone or combined with other modalities.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats under broad-wavelength conditions spontaneously recognize an object even when views differ by angle, size, and position.",
+                "claim_b": "Rats under broad-wavelength conditions spontaneously recognize an object even when views differ by angle, size, and position.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The present study extends the range of visual perceptual functions for which rats can serve as models, characterizing their performance in judging object orientation and indicating the longest illumination wavelengths at which this capacity remains intact.",
+                "claim_b": "The present study extends the range of visual perceptual functions for which rats can serve as models.",
+                "similarity": "0.79"
+              },
+              {
+                "claim_a": "Rats and mice are the most frequently used laboratory mammals, ideal for research on spatial navigation.",
+                "claim_b": "Rats and mice are the most frequently used laboratory mammals.",
+                "similarity": "0.75"
+              }
+            ]
+          },
+          {
+            "ids": "R4 \u2194 R5",
+            "result_similarity": "0.58",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "3 (A) / 2 (B)",
+            "n_matched_claims": 1,
+            "claim_set_jaccard": "0.25",
+            "avg_claim_similarity": "0.52",
+            "result_a": "Rats performed at chance level under infrared illumination at 854 nm (53\u00b12%, p=0.257 vs chance) and 930 nm (50\u00b11%, p=0.316 vs chance), indicating functional blindness at these wavelengths.",
+            "result_b": "Illumination at 850 nm provides optimal conditions for vision-excluded behavioral studies, as it does not support visual form capacity but remains detectable by standard video cameras, allowing behavioral documentation without providing visual cues to the animal.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats performed poorly under infrared illumination, comprising 854 nm and 930 nm light.",
+                "claim_b": "Behaviors may be documented by video while the animal performs without visual cues at 850 nm illumination.",
+                "similarity": "0.52"
+              }
+            ]
+          }
+        ],
+        "unmatched_a": [
+          "Visual discrimination performance degraded at longer wavelengths, with diminished but still above-chance performance at 729 nm (72\u00b13%, p=0.00 vs white light) and near-chance performance at 854 nm and above. This establishes a wavelength-dependent decline in visual capacity.",
+          "The visual performance under red LEDs cannot be explained by spectral leakage to shorter wavelengths. Infrared LEDs emitted 2-50 times higher intensity at shorter wavelengths than red LEDs, yet produced chance-level performance, indicating that red light itself supports discrimination.",
+          "Despite lacking red cones, rats can absorb red light through their rod-dominated retina to support form vision. Prior ERG studies showed retinal responses to red light, but whether this translates to behaviorally meaningful signals was previously unknown. The current study addresses this gap.",
+          "Background on rat visual system: rats are crepuscular with rod-dominated retinas (1% cones), rods are 100x more sensitive than cones with peak absorption at 498 nm, and rats have dichromatic color vision based on UV (358-359 nm) and green (509-510 nm) cones but poor wavelength discrimination."
+        ],
+        "unmatched_b": [
+          "The study used four male Long-Evans rats, 8 weeks old at arrival, water-deprived during testing sessions, rewarded with diluted pear juice, under protocols approved by institutional ethics committees."
+        ]
+      }
+    },
+    {
+      "label_a": "unsegmented",
+      "label_b": "pypdf4llm",
+      "n_results_a": 10,
+      "n_results_b": 11,
+      "avg_result_similarity": 0.7796,
+      "result_match_rate": 0.7273,
+      "evaluation_type_agreement": 0.875,
+      "result_type_agreement": 0.875,
+      "avg_claim_set_jaccard": 0.5569,
+      "avg_claim_similarity": 0.8809,
+      "distribution_a": {
+        "evaluation_type": {
+          "SUPPORTED": 9,
+          "UNCERTAIN": 1
+        },
+        "result_type": {
+          "MINOR": 5,
+          "MAJOR": 5
+        }
+      },
+      "distribution_b": {
+        "evaluation_type": {
+          "SUPPORTED": 10,
+          "UNCERTAIN": 1
+        },
+        "result_type": {
+          "MAJOR": 4,
+          "MINOR": 7
+        }
+      },
+      "summary": {
+        "pair": "unsegmented \u2194 pypdf4llm",
+        "metrics": {
+          "results": "10 vs 11",
+          "matched_pairs": 8,
+          "unmatched_a": 2,
+          "unmatched_b": 3,
+          "result_level": {
+            "avg_result_similarity": "78.0%",
+            "result_match_rate": "72.7%",
+            "evaluation_type_agreement": "87.5%",
+            "result_type_agreement": "87.5%"
+          },
+          "claim_set_level": {
+            "avg_claim_set_jaccard": "55.7%",
+            "avg_claim_similarity": "88.1%"
+          }
+        },
+        "evaluation_type_distribution": {
+          "SUPPORTED": {
+            "unsegmented": 9,
+            "pypdf4llm": 10
+          },
+          "UNCERTAIN": {
+            "unsegmented": 1,
+            "pypdf4llm": 1
+          }
+        },
+        "result_type_distribution": {
+          "MAJOR": {
+            "unsegmented": 5,
+            "pypdf4llm": 4
+          },
+          "MINOR": {
+            "unsegmented": 5,
+            "pypdf4llm": 7
+          }
+        },
+        "matched_pairs": [
+          {
+            "ids": "R5 \u2194 R2",
+            "result_similarity": "0.89",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "2 (A) / 2 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "1.00",
+            "avg_claim_similarity": "1.00",
+            "result_a": "The visual performance under red LEDs cannot be explained by spectral leakage to shorter wavelengths. Infrared LEDs emitted 2-50 times higher intensity at shorter wavelengths than red LEDs, yet produced chance-level performance, indicating that red light itself supports discrimination.",
+            "result_b": "Visual performance under red LEDs (626 nm and 652 nm) is attributable to red light absorption rather than spectral leakage to shorter wavelengths. Infrared LEDs (854 nm and 930 nm) emitted 2-50 times higher intensity at shorter wavelengths than red LEDs, yet produced only chance-level performance.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Performance under red LEDs is better explained by positing that enough red light was absorbed to guide the discrimination.",
+                "claim_b": "Performance under red LEDs is better explained by positing that enough red light was absorbed to guide the discrimination.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Visual acuity under the red LEDs (626 nm and 652 nm) cannot be explained by unintended 'leakage' toward shorter wavelengths.",
+                "claim_b": "Visual acuity under red LEDs (626 nm and 652 nm) cannot be explained by unintended 'leakage' toward shorter wavelengths.",
+                "similarity": "1.00"
+              }
+            ]
+          },
+          {
+            "ids": "R8 \u2194 R5",
+            "result_similarity": "0.88",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "7 (A) / 9 (B)",
+            "n_matched_claims": 7,
+            "claim_set_jaccard": "0.78",
+            "avg_claim_similarity": "0.99",
+            "result_a": "Background on rat visual system: rats are crepuscular with rod-dominated retinas (1% cones), rods are 100x more sensitive than cones with peak absorption at 498 nm, and rats have dichromatic color vision based on UV (358-359 nm) and green (509-510 nm) cones but poor wavelength discrimination.",
+            "result_b": "Rats are dichromatic rodents with UV (358-359 nm) and green (509-510 nm) cone types but lacking red cones, possess rod-dominated retinas (cones <1% of photoreceptors), with rods ~100x more sensitive than cones and peak rhodopsin absorption at 498 nm. Despite lacking red cones, rats are not color-blind but perform poorly at discriminating nearby wavelengths compared to humans.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rods are about 100 times more sensitive than cones.",
+                "claim_b": "Rods are about 100 times more sensitive than cones.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rat retina is rod dominated, with cones making up as little as 1% of photoreceptors.",
+                "claim_b": "Rat retina is rod dominated, with cones making up as little as 1% of photoreceptors.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Peak spectral absorption of rhodopsin in rods in rats and mice is at 498 nm.",
+                "claim_b": "Peak spectral absorption of rhodopsin in rods in rats and mice is at 498 nm.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats are not color-blind.",
+                "claim_b": "Rats are not color-blind.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats perform poorly in discriminating between nearby wavelengths, compared to humans.",
+                "claim_b": "Rats perform poorly in discriminating between nearby wavelengths compared to humans.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats are largely crepuscular and are usually found in poorly illuminated environments during daylight.",
+                "claim_b": "Rats are largely crepuscular and usually found in poorly illuminated environments during daylight.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats' color sensitivity is based on two sets of cones with peak sensitivities in the range of ultraviolet (UV cones; peak absorption at 358-359 nm) and green (M cones; peak absorption at 509-510 nm).",
+                "claim_b": "Rats' color sensitivity is based on two sets of cones with peak sensitivities in the range of ultraviolet (358\u2013359 nm) and green (509\u2013510 nm).",
+                "similarity": "0.97"
+              }
+            ]
+          },
+          {
+            "ids": "R2 \u2194 R1",
+            "result_similarity": "0.85",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "7 (A) / 13 (B)",
+            "n_matched_claims": 7,
+            "claim_set_jaccard": "0.54",
+            "avg_claim_similarity": "0.91",
+            "result_a": "Long-Evans rats successfully performed visual orientation discrimination under red light (626 nm and 652 nm) with accuracy equivalent to white light (84-86% vs 87% correct). All four rats performed well under white LED illumination, and dark-adapted rats maintained this performance under red LEDs, demonstrating conserved visual capacity.",
+            "result_b": "Long-Evans rats (N=4) demonstrated substantial visual form discrimination capacity under red and far-red illumination. Performance under 626 nm and 652 nm red light (84\u00b13% and 86\u00b12% correct, respectively) was statistically equivalent to white light (87\u00b12%, p>0.15), while performance degraded at 729 nm (72\u00b13%, p=0.00) and reached chance levels at infrared wavelengths 854 nm and 930 nm (53\u00b12% and 50\u00b11%, both p>0.25 vs. chance).",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Average performance was 87 \u00b1 2% correct under white light.",
+                "claim_b": "Average performance was 87 \u00b1 2% correct under white light.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Dark-adapted rats performed the visual categorization task under 626 nm and 652 nm LEDs with accuracy equivalent to that under white light.",
+                "claim_b": "Dark-adapted rats performed the visual categorization task under 626 nm and 652 nm LEDs with accuracy equivalent to that under white light.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Average performance was 84 \u00b1 3% under 626 nm illumination (p=0.158 compared to white light).",
+                "claim_b": "Average performance was 84 \u00b1 3% under 626 nm illumination with p=0.158 compared to white light.",
+                "similarity": "0.99"
+              },
+              {
+                "claim_a": "Average performance was 86 \u00b1 2% under 652 nm (p=0.419 compared to white light).",
+                "claim_b": "Average performance was 86 \u00b1 2% under 652 nm illumination with p=0.419 compared to white light.",
+                "similarity": "0.95"
+              },
+              {
+                "claim_a": "All rats (N = 4) performed well under white LED illumination.",
+                "claim_b": "All four rats performed well under white LED illumination.",
+                "similarity": "0.95"
+              },
+              {
+                "claim_a": "Long-Evans rats can discriminate visual form under red light of various wavelength bands.",
+                "claim_b": "Long-Evans rats can perform visual form discrimination under red light.",
+                "similarity": "0.89"
+              },
+              {
+                "claim_a": "Rats can distinguish between horizontal and vertical orientations of a black and white grating under red light.",
+                "claim_b": "Rats performed poorly under infrared illumination comprising 854 nm and 930 nm light.",
+                "similarity": "0.57"
+              }
+            ]
+          },
+          {
+            "ids": "R6 \u2194 R6",
+            "result_similarity": "0.81",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "6 (A) / 3 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "0.72",
+            "result_a": "Despite lacking red cones, rats can absorb red light through their rod-dominated retina to support form vision. Prior ERG studies showed retinal responses to red light, but whether this translates to behaviorally meaningful signals was previously unknown. The current study addresses this gap.",
+            "result_b": "Prior electroretinogram studies show conflicting results regarding rodent retinal responses to red light. Rocha et al. (2016) found no significant response above 620 nm in Wistar rats, while Niklaus et al. (2020) demonstrated significant scotopic and photopic ERG responses to 656\u00b110 nm red light at low intensities in both Brown Norway and Wistar rats.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Both rat strains showed significant scotopic and photopic ERG responses to red light even at low intensities.",
+                "claim_b": "Both Brown Norway and Wistar rat strains showed significant scotopic and photopic ERG responses to red light (656 \u00b1 10 nm) even at low intensities.",
+                "similarity": "0.93"
+              },
+              {
+                "claim_a": "Whether the photoreceptor activation by red light can lead to functionally meaningful signals has not yet been established.",
+                "claim_b": "A study by Niklaus et al., 2020 showed significant scotopic and photopic ERG responses to red light even at low intensities.",
+                "similarity": "0.69"
+              },
+              {
+                "claim_a": "A recent study examined the retinal responses mediated by rods and cones of pigmented (Brown Norway) and albino (Wistar) rats in response to monochromatic far-red light of 656 \u00b1 10 nm in both photopic and scotopic settings.",
+                "claim_b": "Electroretinogram measurements of Wistar rats identified two sensitivity peaks at 362 and 502 nm with no significant response to long wavelength light above 620 nm.",
+                "similarity": "0.55"
+              }
+            ]
+          },
+          {
+            "ids": "R1 \u2194 R3",
+            "result_similarity": "0.79",
+            "evaluation_type_match": true,
+            "result_type_match": false,
+            "claims": "9 (A) / 5 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.56",
+            "avg_claim_similarity": "0.90",
+            "result_a": "The manuscript challenges the widespread assumption that rats are functionally blind under red light. This assumption is based on rats being dichromats lacking red cones, and prior ERG studies showing no significant response above 620 nm. However, conflicting evidence exists, with another study showing ERG responses to red light. Red light has been commonly used in behavioral experiments under the assumption it provides darkness for the animal.",
+            "result_b": "The common assumption that rodents are functionally blind under red light in behavioral and physiological experiments is challenged. Multiple research domains including place-cell studies, circadian rhythm research, and general behavioral neuroscience have operated under this assumption, but animals may acquire more visual input than previously believed.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Red illumination is often used in reverse light cycle conditions in animal husbandry settings with the assumption that it will not affect rodent circadian rhythms.",
+                "claim_b": "Red illumination is often used in reverse light cycle conditions in animal husbandry settings with the assumption that it will not affect rodent circadian rhythms.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Place-cell studies of rats navigating under dim red light have taken red light as the absence of visual input.",
+                "claim_b": "Place-cell studies of rats navigating under dim red light have been conducted with the assumption of absence of visual input.",
+                "similarity": "0.98"
+              },
+              {
+                "claim_a": "Rodent behavioral experiments done under red light are believed to place the animal in dark conditions while allowing the experimenter to observe the preparation directly or by video recording.",
+                "claim_b": "Rodent behavioral experiments done under red light are believed to place the animal in dark conditions while allowing the experimenter to observe the preparation.",
+                "similarity": "0.97"
+              },
+              {
+                "claim_a": "Rats and mice are assumed to be functionally blind under red light.",
+                "claim_b": "Rats should not be assumed to be blind under red light in investigations exploring rodent physiological and behavioral functions.",
+                "similarity": "0.89"
+              },
+              {
+                "claim_a": "In a developmental study of the visual cortex, mice were dark-reared but were allowed very brief daily exposure to red light.",
+                "claim_b": "Animals in studies using red light may acquire more visual input than previously believed.",
+                "similarity": "0.66"
+              }
+            ]
+          },
+          {
+            "ids": "R9 \u2194 R9",
+            "result_similarity": "0.70",
+            "evaluation_type_match": false,
+            "result_type_match": true,
+            "claims": "4 (A) / 2 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "0.99",
+            "result_a": "The mechanisms underlying red light detection remain speculative. Possibilities include unconscious circadian entrainment, cross-retina population coding to amplify weak signals, or nonlinear processes like two-photon activation, though the latter is unlikely given the low light intensities used.",
+            "result_b": "Red light may have non-conscious effects on rodents, such as entraining circadian rhythms, and can produce behavioral artifacts in optogenetic experiments as demonstrated in mice performing visual discrimination tasks.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Red light might act to entrain circadian rhythms, unconscious to the animal.",
+                "claim_b": "Red light might act to entrain circadian rhythms, unconscious to the animal.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "The sensitivity of mice is emphasized by the finding that red illumination delivered into the brain in an optogenetic protocol evoked a behavioral artifact in mice performing a visually guided discrimination task.",
+                "claim_b": "Red illumination delivered into the brain in an optogenetic protocol evoked a behavioral artifact in mice performing a visually guided discrimination task.",
+                "similarity": "0.98"
+              }
+            ]
+          },
+          {
+            "ids": "R10 \u2194 R11",
+            "result_similarity": "0.69",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "6 (A) / 18 (B)",
+            "n_matched_claims": 6,
+            "claim_set_jaccard": "0.33",
+            "avg_claim_similarity": "0.54",
+            "result_a": "The study extends the range of visual perceptual functions for which rats serve as models, characterizing orientation discrimination across wavelengths. This has implications for experimental design and animal welfare in laboratory settings.",
+            "result_b": "The study used four male Long-Evans rats (8 weeks old, ~250g initially, growing to >600g) maintained on 12/12hr light/dark cycles with experiments during light phase. Rats were dark-adapted 20-30 minutes before sessions and tested on orientation discrimination of a 9.8cm diameter grating stimulus (0.075 cpd spatial frequency, expected to be resolvable given ~1 cpd rat acuity) covering the 117\u00b0 binocular field. Training required 4-6 weeks with randomized illumination conditions.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "A complete understanding of the visual processing of these animals is important not only in the design and control of the behavioral and physiological experiments but also to ensure optimal environmental lighting conditions for their well-being in laboratory settings.",
+                "claim_b": "Rats were dark-adapted in a light-free environment for 20\u201330 min prior to each session.",
+                "similarity": "0.61"
+              },
+              {
+                "claim_a": "There is growing interest in the use of rodents for the study of vision, alone or combined with other modalities.",
+                "claim_b": "Rats have a large depth of focus, from 7 cm to infinity.",
+                "similarity": "0.59"
+              },
+              {
+                "claim_a": "The present study extends the range of visual perceptual functions for which rats can serve as models, characterizing their performance in judging object orientation and indicating the longest illumination wavelengths at which this capacity remains intact.",
+                "claim_b": "The normal visual acuity of Long-Evans rats has been estimated as ~1 cpd.",
+                "similarity": "0.57"
+              },
+              {
+                "claim_a": "Rats under broad-wavelength conditions spontaneously recognize an object even when views differ by angle, size, and position.",
+                "claim_b": "The 117\u00b0 stimulus should completely cover the rat's binocular visual field.",
+                "similarity": "0.55"
+              },
+              {
+                "claim_a": "Rats and mice are the most frequently used laboratory mammals, ideal for research on spatial navigation.",
+                "claim_b": "Four male Long-Evans rats from Charles River Laboratories were used in the study.",
+                "similarity": "0.48"
+              },
+              {
+                "claim_a": "Rats achieve high-level sensory-perceptual cognition through the workings of neuronal circuits that are accessible.",
+                "claim_b": "The sequence of sessions for each rat was randomized, with each day's session illuminated by either red, infrared, or white LEDs, with equal likelihood.",
+                "similarity": "0.41"
+              }
+            ]
+          },
+          {
+            "ids": "R7 \u2194 R4",
+            "result_similarity": "0.62",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "4 (A) / 1 (B)",
+            "n_matched_claims": 1,
+            "claim_set_jaccard": "0.25",
+            "avg_claim_similarity": "1.00",
+            "result_a": "The findings have important implications for experimental design: researchers should not assume red-light blindness in rodents, and illumination at 850 nm provides optimal conditions for vision-excluded studies while remaining detectable by standard cameras.",
+            "result_b": "Illumination at 850 nm provides optimal conditions for vision-excluded behavioral studies, as it does not support visual form capacity while remaining within the sensitivity range of standard CMOS and CCD detectors for video recording.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Illumination at 850 nm did not support visual form capacity, yet remains within the sensitivity range of inexpensive silicone detectors (CMOS and CCDs).",
+                "claim_b": "Illumination at 850 nm did not support visual form capacity, yet remains within the sensitivity range of inexpensive silicone detectors (CMOS and CCDs).",
+                "similarity": "1.00"
+              }
+            ]
+          }
+        ],
+        "unmatched_a": [
+          "Visual discrimination performance degraded at longer wavelengths, with diminished but still above-chance performance at 729 nm (72\u00b13%, p=0.00 vs white light) and near-chance performance at 854 nm and above. This establishes a wavelength-dependent decline in visual capacity.",
+          "Rats performed at chance level under infrared illumination at 854 nm (53\u00b12%, p=0.257 vs chance) and 930 nm (50\u00b11%, p=0.316 vs chance), indicating functional blindness at these wavelengths."
+        ],
+        "unmatched_b": [
+          "The inability to see red as a color does not preclude red light absorption through rod-dominated retina for form vision. Retinal receptor excitation does not automatically indicate behavioral signal availability, and mechanisms must exist for converting minimal receptor activation into meaningful signals, possibly through cross-retina population coding.",
+          "Two-photon activation of photopigments could theoretically enable photoreceptor responses to longer wavelengths, though the emission intensities used in this study are many orders of magnitude lower than those required for two-photon processes.",
+          "Rats and mice are the most frequently used laboratory mammals with growing interest in vision research. Rats demonstrate high-level visual perception including view-invariant object recognition (previously thought exclusive to primates) through accessible neuronal circuits."
+        ]
+      }
+    },
+    {
+      "label_a": "segmented",
+      "label_b": "pypdf4llm",
+      "n_results_a": 7,
+      "n_results_b": 11,
+      "avg_result_similarity": 0.8269,
+      "result_match_rate": 0.5455,
+      "evaluation_type_agreement": 0.8333,
+      "result_type_agreement": 1.0,
+      "avg_claim_set_jaccard": 0.5438,
+      "avg_claim_similarity": 0.8993,
+      "distribution_a": {
+        "evaluation_type": {
+          "SUPPORTED": 7
+        },
+        "result_type": {
+          "MAJOR": 2,
+          "MINOR": 5
+        }
+      },
+      "distribution_b": {
+        "evaluation_type": {
+          "SUPPORTED": 10,
+          "UNCERTAIN": 1
+        },
+        "result_type": {
+          "MAJOR": 4,
+          "MINOR": 7
+        }
+      },
+      "summary": {
+        "pair": "segmented \u2194 pypdf4llm",
+        "metrics": {
+          "results": "7 vs 11",
+          "matched_pairs": 6,
+          "unmatched_a": 1,
+          "unmatched_b": 5,
+          "result_level": {
+            "avg_result_similarity": "82.7%",
+            "result_match_rate": "54.5%",
+            "evaluation_type_agreement": "83.3%",
+            "result_type_agreement": "100.0%"
+          },
+          "claim_set_level": {
+            "avg_claim_set_jaccard": "54.4%",
+            "avg_claim_similarity": "89.9%"
+          }
+        },
+        "evaluation_type_distribution": {
+          "SUPPORTED": {
+            "segmented": 7,
+            "pypdf4llm": 10
+          },
+          "UNCERTAIN": {
+            "segmented": 0,
+            "pypdf4llm": 1
+          }
+        },
+        "result_type_distribution": {
+          "MAJOR": {
+            "segmented": 2,
+            "pypdf4llm": 4
+          },
+          "MINOR": {
+            "segmented": 5,
+            "pypdf4llm": 7
+          }
+        },
+        "matched_pairs": [
+          {
+            "ids": "R1 \u2194 R1",
+            "result_similarity": "0.91",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "25 (A) / 13 (B)",
+            "n_matched_claims": 13,
+            "claim_set_jaccard": "0.52",
+            "avg_claim_similarity": "0.91",
+            "result_a": "Long-Evans rats retain substantial visual form discrimination capacity under red light (626 nm and 652 nm), with performance equivalent to white light, challenging the assumption of functional blindness. Performance degrades at 729 nm and approaches chance at infrared wavelengths (854 nm, 930 nm). The visual capacity under red light is attributed to absorption of red light by photoreceptors rather than spectral leakage from LEDs.",
+            "result_b": "Long-Evans rats (N=4) demonstrated substantial visual form discrimination capacity under red and far-red illumination. Performance under 626 nm and 652 nm red light (84\u00b13% and 86\u00b12% correct, respectively) was statistically equivalent to white light (87\u00b12%, p>0.15), while performance degraded at 729 nm (72\u00b13%, p=0.00) and reached chance levels at infrared wavelengths 854 nm and 930 nm (53\u00b12% and 50\u00b11%, both p>0.25 vs. chance).",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Average performance was 87 \u00b1 2% correct under white light.",
+                "claim_b": "Average performance was 87 \u00b1 2% correct under white light.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Object discrimination began to degrade when illumination wavelength increased from 652 to 729 nm and was almost nil at 854 nm.",
+                "claim_b": "Object discrimination began to degrade when illumination wavelength increased from 652 to 729 nm and was almost nil at 854 nm.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Dark-adapted rats performed the visual categorization task under 626 nm and 652 nm LEDs with accuracy equivalent to that under white light.",
+                "claim_b": "Dark-adapted rats performed the visual categorization task under 626 nm and 652 nm LEDs with accuracy equivalent to that under white light.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats performed poorly under infrared illumination, comprising 854 nm and 930 nm light.",
+                "claim_b": "Rats performed poorly under infrared illumination comprising 854 nm and 930 nm light.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Average performance was 84 \u00b1 3% under 626 nm illumination (p=0.158 compared to white light).",
+                "claim_b": "Average performance was 84 \u00b1 3% under 626 nm illumination with p=0.158 compared to white light.",
+                "similarity": "0.99"
+              },
+              {
+                "claim_a": "Rats performed well under peak 729 nm, though clearly diminished with respect to white light.",
+                "claim_b": "Rats performed well under peak 729 nm illumination, though clearly diminished with respect to white light.",
+                "similarity": "0.96"
+              },
+              {
+                "claim_a": "Average performance was 72 \u00b1 3% under 729 nm (p=0.00 compared to white light).",
+                "claim_b": "Average performance was 72 \u00b1 3% under 729 nm illumination with p=0.00 compared to white light.",
+                "similarity": "0.95"
+              },
+              {
+                "claim_a": "Average performance was 86 \u00b1 2% under 652 nm (p=0.419 compared to white light).",
+                "claim_b": "Average performance was 86 \u00b1 2% under 652 nm illumination with p=0.419 compared to white light.",
+                "similarity": "0.95"
+              },
+              {
+                "claim_a": "All rats (N = 4) performed well under white LED illumination.",
+                "claim_b": "All four rats performed well under white LED illumination.",
+                "similarity": "0.95"
+              },
+              {
+                "claim_a": "Long-Evans rats can discriminate visual form under red light of various wavelength bands.",
+                "claim_b": "Long-Evans rats can perform visual form discrimination under red light.",
+                "similarity": "0.89"
+              },
+              {
+                "claim_a": "Average performance was 50 \u00b1 1% under 930 nm (p=0.316 compared to chance).",
+                "claim_b": "Average performance was 50 \u00b1 1% under 930 nm illumination with p=0.316 compared to chance.",
+                "similarity": "0.84"
+              },
+              {
+                "claim_a": "Average performance was 53 \u00b1 2% under 854 nm (p=0.257 compared to chance).",
+                "claim_b": "Average performance was 53 \u00b1 2% under 854 nm illumination with p=0.257 compared to chance.",
+                "similarity": "0.81"
+              },
+              {
+                "claim_a": "Rats had to distinguish between horizontal and vertical orientations of a black and white grating.",
+                "claim_b": "Four Long-Evans rats were used in the study.",
+                "similarity": "0.46"
+              }
+            ]
+          },
+          {
+            "ids": "R6 \u2194 R10",
+            "result_similarity": "0.88",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "7 (A) / 5 (B)",
+            "n_matched_claims": 5,
+            "claim_set_jaccard": "0.71",
+            "avg_claim_similarity": "0.98",
+            "result_a": "Rats are increasingly used as models for visual perception research, demonstrating sophisticated visual capacities including view-invariant object recognition through accessible neural circuits. The present study extends understanding of rat visual capabilities and has implications for experimental design and animal welfare.",
+            "result_b": "Rats and mice are the most frequently used laboratory mammals with growing interest in vision research. Rats demonstrate high-level visual perception including view-invariant object recognition (previously thought exclusive to primates) through accessible neuronal circuits.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rats and mice are the most frequently used laboratory mammals.",
+                "claim_b": "Rats and mice are the most frequently used laboratory mammals.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats achieve high-level sensory-perceptual cognition through the workings of neuronal circuits that are accessible.",
+                "claim_b": "Rats achieve high-level sensory-perceptual cognition through the workings of neuronal circuits that are accessible.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "There is growing interest in the use of rodents for the study of vision, alone or combined with other modalities.",
+                "claim_b": "There is growing interest in the use of rodents for the study of vision, alone or combined with other modalities.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats under broad-wavelength conditions spontaneously recognize an object even when views differ by angle, size, and position.",
+                "claim_b": "Rats under broad-wavelength conditions spontaneously recognize an object even when views differ by angle, size, and position.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Such generalization is a hallmark of authentic visual perception and was once believed to belong only to primates.",
+                "claim_b": "Object generalization across different views is a hallmark of authentic visual perception and was once believed to belong only to primates.",
+                "similarity": "0.92"
+              }
+            ]
+          },
+          {
+            "ids": "R2 \u2194 R5",
+            "result_similarity": "0.86",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "15 (A) / 9 (B)",
+            "n_matched_claims": 9,
+            "claim_set_jaccard": "0.60",
+            "avg_claim_similarity": "0.96",
+            "result_a": "Prior literature establishes that rats are dichromatic with UV and green cones but lack red cones, have rod-dominated retinas, and show poor wavelength discrimination. Recent ERG studies show conflicting results regarding red light sensitivity, with one study finding no response above 620 nm and another finding significant responses to far-red light.",
+            "result_b": "Rats are dichromatic rodents with UV (358-359 nm) and green (509-510 nm) cone types but lacking red cones, possess rod-dominated retinas (cones <1% of photoreceptors), with rods ~100x more sensitive than cones and peak rhodopsin absorption at 498 nm. Despite lacking red cones, rats are not color-blind but perform poorly at discriminating nearby wavelengths compared to humans.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Rods are about 100 times more sensitive than cones.",
+                "claim_b": "Rods are about 100 times more sensitive than cones.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rat retina is rod dominated, with cones making up as little as 1% of photoreceptors.",
+                "claim_b": "Rat retina is rod dominated, with cones making up as little as 1% of photoreceptors.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats are largely crepuscular and usually found in poorly illuminated environments during daylight.",
+                "claim_b": "Rats are largely crepuscular and usually found in poorly illuminated environments during daylight.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rodents lack red cones.",
+                "claim_b": "Rodents lack red cones.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Peak spectral absorption of rhodopsin in rods in rats and mice is at 498 nm.",
+                "claim_b": "Peak spectral absorption of rhodopsin in rods in rats and mice is at 498 nm.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats are not color-blind.",
+                "claim_b": "Rats are not color-blind.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats perform poorly in discriminating between nearby wavelengths, compared to humans.",
+                "claim_b": "Rats perform poorly in discriminating between nearby wavelengths compared to humans.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Rats' color sensitivity is based on two sets of cones with peak sensitivities in the range of ultraviolet (UV cones; peak absorption at 358-359 nm) and green (M cones; peak absorption at 509-510 nm).",
+                "claim_b": "Rats' color sensitivity is based on two sets of cones with peak sensitivities in the range of ultraviolet (358\u2013359 nm) and green (509\u2013510 nm).",
+                "similarity": "0.97"
+              },
+              {
+                "claim_a": "From the inability to see red as a color, it does not necessarily follow that rodents cannot absorb red light through their rod-dominated retina to support form vision.",
+                "claim_b": "Rats and mice are dichromats who possess ultraviolet and green cones, but not red cones.",
+                "similarity": "0.65"
+              }
+            ]
+          },
+          {
+            "ids": "R5 \u2194 R4",
+            "result_similarity": "0.83",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "2 (A) / 1 (B)",
+            "n_matched_claims": 1,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "1.00",
+            "result_a": "Illumination at 850 nm provides optimal conditions for vision-excluded behavioral studies, as it does not support visual form capacity but remains detectable by standard video cameras, allowing behavioral documentation without providing visual cues to the animal.",
+            "result_b": "Illumination at 850 nm provides optimal conditions for vision-excluded behavioral studies, as it does not support visual form capacity while remaining within the sensitivity range of standard CMOS and CCD detectors for video recording.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Illumination at 850 nm did not support visual form capacity, yet remains within the sensitivity range of inexpensive silicone detectors (CMOS and CCDs).",
+                "claim_b": "Illumination at 850 nm did not support visual form capacity, yet remains within the sensitivity range of inexpensive silicone detectors (CMOS and CCDs).",
+                "similarity": "1.00"
+              }
+            ]
+          },
+          {
+            "ids": "R3 \u2194 R9",
+            "result_similarity": "0.76",
+            "evaluation_type_match": true,
+            "result_type_match": true,
+            "claims": "4 (A) / 2 (B)",
+            "n_matched_claims": 2,
+            "claim_set_jaccard": "0.50",
+            "avg_claim_similarity": "0.69",
+            "result_a": "Red light illumination is widely used in rodent behavioral research under the assumption that it creates functionally dark conditions while allowing experimenter observation, including in place-cell studies, developmental studies, and animal husbandry settings.",
+            "result_b": "Red light may have non-conscious effects on rodents, such as entraining circadian rhythms, and can produce behavioral artifacts in optogenetic experiments as demonstrated in mice performing visual discrimination tasks.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Red illumination is often used in reverse light cycle conditions in animal husbandry settings with the assumption that it will not affect rodent circadian rhythms.",
+                "claim_b": "Red light might act to entrain circadian rhythms, unconscious to the animal.",
+                "similarity": "0.75"
+              },
+              {
+                "claim_a": "In a developmental study of the visual cortex, mice were dark-reared but were allowed very brief daily exposure to red light.",
+                "claim_b": "Red illumination delivered into the brain in an optogenetic protocol evoked a behavioral artifact in mice performing a visually guided discrimination task.",
+                "similarity": "0.63"
+              }
+            ]
+          },
+          {
+            "ids": "R4 \u2194 R7",
+            "result_similarity": "0.72",
+            "evaluation_type_match": false,
+            "result_type_match": true,
+            "claims": "7 (A) / 3 (B)",
+            "n_matched_claims": 3,
+            "claim_set_jaccard": "0.43",
+            "avg_claim_similarity": "0.86",
+            "result_a": "The gap between physiological photoreceptor activation and behaviorally meaningful visual signals under red light had not been established. The study does not directly measure photoreceptor sensitivity but infers that mechanisms must exist to convert minimal receptor activation into functional signals. Two-photon activation is considered unlikely given the low light intensities used.",
+            "result_b": "The inability to see red as a color does not preclude red light absorption through rod-dominated retina for form vision. Retinal receptor excitation does not automatically indicate behavioral signal availability, and mechanisms must exist for converting minimal receptor activation into meaningful signals, possibly through cross-retina population coding.",
+            "matched_claim_pairs": [
+              {
+                "claim_a": "Mechanisms must exist for converting miniscule quantities of receptor activation into meaningful signals, perhaps through some cross-retina population code.",
+                "claim_b": "Mechanisms must exist for converting miniscule quantities of receptor activation into meaningful signals, perhaps through some cross-retina population code.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Excitation of retinal receptors by red light does not, by itself, indicate behavioral availability of the signal.",
+                "claim_b": "Excitation of retinal receptors by red light does not, by itself, indicate behavioral availability of the signal.",
+                "similarity": "1.00"
+              },
+              {
+                "claim_a": "Red light might act to entrain circadian rhythms, unconscious to the animal.",
+                "claim_b": "The inability to see red as a color does not necessarily mean rodents cannot absorb red light through their rod-dominated retina to support form vision.",
+                "similarity": "0.57"
+              }
+            ]
+          }
+        ],
+        "unmatched_a": [
+          "The study used four male Long-Evans rats, 8 weeks old at arrival, water-deprived during testing sessions, rewarded with diluted pear juice, under protocols approved by institutional ethics committees."
+        ],
+        "unmatched_b": [
+          "Visual performance under red LEDs (626 nm and 652 nm) is attributable to red light absorption rather than spectral leakage to shorter wavelengths. Infrared LEDs (854 nm and 930 nm) emitted 2-50 times higher intensity at shorter wavelengths than red LEDs, yet produced only chance-level performance.",
+          "The common assumption that rodents are functionally blind under red light in behavioral and physiological experiments is challenged. Multiple research domains including place-cell studies, circadian rhythm research, and general behavioral neuroscience have operated under this assumption, but animals may acquire more visual input than previously believed.",
+          "Prior electroretinogram studies show conflicting results regarding rodent retinal responses to red light. Rocha et al. (2016) found no significant response above 620 nm in Wistar rats, while Niklaus et al. (2020) demonstrated significant scotopic and photopic ERG responses to 656\u00b110 nm red light at low intensities in both Brown Norway and Wistar rats.",
+          "Two-photon activation of photopigments could theoretically enable photoreceptor responses to longer wavelengths, though the emission intensities used in this study are many orders of magnitude lower than those required for two-photon processes.",
+          "The study used four male Long-Evans rats (8 weeks old, ~250g initially, growing to >600g) maintained on 12/12hr light/dark cycles with experiments during light phase. Rats were dark-adapted 20-30 minutes before sessions and tested on orientation discrimination of a 9.8cm diameter grating stimulus (0.075 cpd spatial frequency, expected to be resolvable given ~1 cpd rat acuity) covering the 117\u00b0 binocular field. Training required 4-6 weeks with randomized illumination conditions."
+        ]
+      }
+    }
+  ]
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,6 +71,8 @@
                     <tbody id="runs-tbody"></tbody>
                 </table>
 
+                <section id="results-comparison-section" class="hidden"></section>
+
                 <section class="comparison-section">
                     <div class="comparison-header">
                         <h2>Compare Runs</h2>


### PR DESCRIPTION
- Add compare_results.py to compare eval_llm outputs across runs at two levels: result-level (cosine similarity of result descriptions) and claim-set-level (Jaccard + similarity of claims within matched result pairs). Outputs a structured JSON report with human-readable summaries for UI rendering.
- Run comparison reports for 2018.01.003 and eLife.66429 (papers with multiple runs)
- Add GET /api/papers/{paper_id}/results-comparison endpoint
- Add Run Similarity Analysis section to the runs list page, appearing before the Compare Runs ranking section when a report exists: summary metrics table and per-pair accordion with distributions, matched results, and claim pairs
- Add styled CSS tooltips on metric column headers explaining each metric